### PR TITLE
Updated font_controls.dart after Feature Request

### DIFF
--- a/lib/ui/widgets/font_controls.dart
+++ b/lib/ui/widgets/font_controls.dart
@@ -209,9 +209,9 @@ class FontControls extends StatelessWidget {
                       final selectedIndex = state.textItems.length - 1;
                       if (selectedIndex >= 0) {
                         context.read<CanvasCubit>().changeTextColor(
-                              selectedIndex,
-                              color,
-                            );
+                          selectedIndex,
+                          color,
+                        );
                       }
                     },
                     child: Container(
@@ -272,6 +272,12 @@ class FontControls extends StatelessWidget {
                 icon: Icons.format_italic,
                 onPressed: () => _changeFontStyle(context, FontStyle.italic),
               ),
+              const SizedBox(width: 8),
+              _buildStyleButton(
+                context: context,
+                icon: Icons.format_clear,
+                onPressed: () => _resetFontStyle(context),
+              ),
             ],
           ),
         ),
@@ -317,6 +323,15 @@ class FontControls extends StatelessWidget {
     }
   }
 
+  void _resetFontStyle(BuildContext context) {
+    final selectedIndex =
+        context.read<CanvasCubit>().state.textItems.length - 1;
+    if (selectedIndex >= 0) {
+      context.read<CanvasCubit>().changeFontWeight(selectedIndex, FontWeight.normal);
+      context.read<CanvasCubit>().changeFontStyle(selectedIndex, FontStyle.normal);
+    }
+  }
+
   void _changeFontSize(BuildContext context, {required bool decrease}) {
     final selectedIndex =
         context.read<CanvasCubit>().state.textItems.length - 1;
@@ -325,9 +340,9 @@ class FontControls extends StatelessWidget {
           context.read<CanvasCubit>().state.textItems[selectedIndex].fontSize;
       final newSize = decrease ? currentSize - 2 : currentSize + 2;
       context.read<CanvasCubit>().changeFontSize(
-            selectedIndex,
-            newSize,
-          );
+        selectedIndex,
+        newSize,
+      );
     }
   }
 


### PR DESCRIPTION

### What kind of change does this PR introduce?
Feature - Added font style reset functionality to text editor controls

### Issue Number:
Fixes #2 

### Snapshots/Videos:
[
<img width="1009" height="93" alt="Screenshot 2025-07-23 140912" src="https://github.com/user-attachments/assets/2ce31cda-4763-4611-a2d4-4fc4bc13096d" />
](url)

### Summary
This PR adds a reset button to the font style controls section that allows users to quickly revert text formatting back to normal state. The existing font controls only allowed applying bold and italic styles but had no way to reset them back to normal, requiring users to manually toggle styles off. This enhancement improves the text editing workflow by providing a single-click solution to clear all font styling.

Changes made:
- Added a new reset button with `format_clear` icon in the Style section of `font_controls.dart`
- Button resets both `fontWeight` to `FontWeight.normal` and `fontStyle` to `FontStyle.normal`
- Follows existing BLoC architecture pattern using `CanvasCubit` methods
- Fixed deprecated `withOpacity()` warnings by replacing with `withValues(alpha:)`
- Corrected package name typos in import statements

### Does this PR introduce a breaking change?
No - This is a purely additive feature that doesn't modify existing functionality or APIs.

### Other information
- Maintains consistent UI styling with existing font control buttons
- Uses standard Material Design `format_clear` icon for intuitive user experience
- Leverages existing cubit methods (`changeFontWeight` and `changeFontStyle`) without requiring backend changes
- Follows the project's established code patterns and architecture

### Have you read the [contributing guide](https://github.com/may-tas/TextEditingApp/blob/main/CONTRIBUTING.md) , [README.md](https://github.com/may-tas/TextEditingApp/blob/main/README.md) , [code of conduct](https://github.com/may-tas/TextEditingApp/blob/main/CODE_OF_CONDUCT.md)?
Yes