### PR TITLE
Refactor: Update color opacity to use `withAlpha`, replacing deprecated `withOpacity`. Added mounted checks between async gaps.

### DIFF
--- a/lib/ui/screens/canvas_screen.dart
+++ b/lib/ui/screens/canvas_screen.dart
@@ -50,7 +50,7 @@ class CanvasScreen extends StatelessWidget {
             end: Alignment.bottomCenter,
             colors: [
               const Color(0xFF1A1A1A),
-              const Color(0xFF1A1A1A).withAlpha(240),
+              const Color(0xFF1A1A1A).withAlpha((0.95 * 255).toInt()),
             ],
           ),
         ),
@@ -93,7 +93,7 @@ class CanvasScreen extends StatelessWidget {
           borderRadius: BorderRadius.circular(12),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withAlpha(25),
+              color: Colors.black.withAlpha((0.05 * 255).toInt()),
               blurRadius: 10,
               offset: const Offset(0, -5),
             ),

--- a/lib/ui/screens/canvas_screen.dart
+++ b/lib/ui/screens/canvas_screen.dart
@@ -50,7 +50,7 @@ class CanvasScreen extends StatelessWidget {
             end: Alignment.bottomCenter,
             colors: [
               const Color(0xFF1A1A1A),
-              const Color(0xFF1A1A1A).withOpacity(0.95),
+              const Color(0xFF1A1A1A).withAlpha(240),
             ],
           ),
         ),
@@ -93,7 +93,7 @@ class CanvasScreen extends StatelessWidget {
           borderRadius: BorderRadius.circular(12),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.05),
+              color: Colors.black.withAlpha(25),
               blurRadius: 10,
               offset: const Offset(0, -5),
             ),

--- a/lib/ui/widgets/editable_text_widget.dart
+++ b/lib/ui/widgets/editable_text_widget.dart
@@ -23,6 +23,7 @@ class EditableTextWidget extends StatelessWidget {
           builder: (context) => EditTextDialog(initialText: textItem.text),
         );
 
+        if(!context.mounted) return;
         if (result == '_delete_') {
           context.read<CanvasCubit>().deleteText(index);
         } else if (result != null) {

--- a/lib/ui/widgets/font_controls.dart
+++ b/lib/ui/widgets/font_controls.dart
@@ -17,7 +17,7 @@ class FontControls extends StatelessWidget {
         color: Colors.white,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withAlpha(25),
+            color: Colors.black.withAlpha((0.1 * 255).toInt()),
             blurRadius: 8,
             offset: const Offset(0, -2),
           ),
@@ -225,7 +225,7 @@ class FontControls extends StatelessWidget {
                         border: Border.all(
                           color: isSelected
                               ? Colors.blue
-                              : Colors.grey.withAlpha(25),
+                              : Colors.grey.withAlpha((0.3 * 255).toInt()),
                           width: isSelected ? 2 : 1,
                         ),
                       ),

--- a/lib/ui/widgets/font_controls.dart
+++ b/lib/ui/widgets/font_controls.dart
@@ -17,7 +17,7 @@ class FontControls extends StatelessWidget {
         color: Colors.white,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withAlpha(25),
             blurRadius: 8,
             offset: const Offset(0, -2),
           ),
@@ -225,7 +225,7 @@ class FontControls extends StatelessWidget {
                         border: Border.all(
                           color: isSelected
                               ? Colors.blue
-                              : Colors.grey.withOpacity(0.3),
+                              : Colors.grey.withAlpha(25),
                           width: isSelected ? 2 : 1,
                         ),
                       ),


### PR DESCRIPTION
### What kind of change does this PR introduce?

This is a refactor and linting change. It updates deprecated method usage and applies best practices for asynchronous widget state management.

### Issue Number:

Fixes #24

### Snapshots/Videos:

N/A – This change primarily impacts code quality and stability, not the UI.

### Summary

This PR addresses the following improvements:

- Replaced deprecated `withOpacity(double)` calls with `withAlpha(int)` where the use of a constant integer alpha makes the intent clearer and more compliant with lint rules like `prefer_int_literals`.

- Added `if (!context.mounted) return;` after `await showDialog(...)` in `EditableTextWidget` to ensure context is still valid before updating state.

- Helps prevent potential runtime errors if the widget is disposed before the dialog completes.

### Does this PR introduce a breaking change?

This PR does not introduce a breaking change. The app will function the same as before but with safer and cleaner code.

### Other information

These changes are part of ongoing cleanup and modernization efforts to align the codebase with current Flutter best practices.
This will also reduce warning noise in CI/CD or local linting environments.

### Have you read the [contributing guide](https://github.com/may-tas/TextEditingApp/blob/main/CONTRIBUTING.md) , [README.md](https://github.com/may-tas/TextEditingApp/blob/main/README.md) , [code of conduct](https://github.com/may-tas/TextEditingApp/blob/main/CODE_OF_CONDUCT.md)?

Yes
