### PR TITLE
Refactor: Enhance font size adjustment with a dialog and slider for better UX

### DIFF
--- a/lib/ui/widgets/font_controls.dart
+++ b/lib/ui/widgets/font_controls.dart
@@ -72,15 +72,22 @@ class FontControls extends StatelessWidget {
                   final fontSize = state.textItems.isNotEmpty
                       ? state.textItems.last.fontSize.round()
                       : 16;
-                  return Container(
-                    constraints: const BoxConstraints(minWidth: 36),
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
-                    child: Text(
-                      '$fontSize',
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.w500,
-                        fontSize: 14,
+                  return InkWell(
+                    onTap: () => {
+                      if (state.textItems.isNotEmpty) {
+                        _handleFontDialog(context, fontSize),
+                      }
+                    },
+                    child: Container(
+                      constraints: const BoxConstraints(minWidth: 36),
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Text(
+                        '$fontSize',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w500,
+                          fontSize: 14,
+                        ),
                       ),
                     ),
                   );
@@ -306,6 +313,62 @@ class FontControls extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  void _handleFontDialog(BuildContext context, int currentSize) {
+
+    final parentContext = context;
+    showDialog(
+      context: parentContext,
+      builder: (dialogContext) {
+        double sliderValue = currentSize.toDouble();
+
+        return StatefulBuilder(
+          builder: (dialogContext, setState) {
+            return AlertDialog(
+              title: const Text('Change Font Size'),
+              content: SizedBox(
+                width: 200,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text('Current Size: ${sliderValue.round()}'),
+                    Slider(
+                      value: sliderValue,
+                      min: 8,
+                      max: 72,
+                      divisions: 32,
+                      label: sliderValue.round().toString(),
+                      onChanged: (value) {
+                        setState(() => sliderValue = value);
+                        _onValueChanged(parentContext, value);
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(dialogContext),
+                  child: const Text('Close'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  void _onValueChanged(BuildContext context, double value) {
+    final selectedIndex =
+        context.read<CanvasCubit>().state.textItems.length - 1;
+    if (selectedIndex >= 0) {
+      context.read<CanvasCubit>().changeFontSize(
+            selectedIndex,
+            value.roundToDouble(),
+          );
+    }
   }
 
   void _changeFontStyle(BuildContext context, FontStyle fontStyle) {


### PR DESCRIPTION
### What kind of change does this PR introduce?

At present, font size adjustments in the app are limited to + and – buttons. While functional, this approach is limited in precision and speed. Users may find it tedious to tap repeatedly to reach a desired size, especially when larger jumps are needed. Introducing a Slider widget inside the font size dialog (triggered by tapping the size number) to allow smoother, more direct font size control.

### Issue Number:

Fixes #27

### Snapshots/Videos:

<img width="377" height="771" alt="image" src="https://github.com/user-attachments/assets/e61adfc1-cb9d-460b-9966-85f897613d20" />

### Summary

This PR enhances the font size control UI by adding a slider inside the font size dialog. Previously, users could only increment or decrement the font size using +/- buttons, which was slow for larger adjustments. Now, tapping the font size opens a dialog with a slider that allows users to quickly and precisely set the desired font size. This provides a more intuitive and efficient editing experience without altering existing behavior or introducing breaking changes.

### Does this PR introduce a breaking change?

No, this doesnot introduce a breaking change. just a UI improvement.

### Have you read the [contributing guide](https://github.com/may-tas/TextEditingApp/blob/main/CONTRIBUTING.md) , [README.md](https://github.com/may-tas/TextEditingApp/blob/main/README.md) , [code of conduct](https://github.com/may-tas/TextEditingApp/blob/main/CODE_OF_CONDUCT.md)?

YES
