### PR TITLE
Refactor: Improve text editing validation and structure in EditTextDialog

### DIFF
--- a/lib/ui/widgets/editable_text_widget.dart
+++ b/lib/ui/widgets/editable_text_widget.dart
@@ -23,7 +23,7 @@ class EditableTextWidget extends StatelessWidget {
           builder: (context) => EditTextDialog(initialText: textItem.text),
         );
 
-        if(!context.mounted) return;
+        if (!context.mounted) return;
         if (result == '_delete_') {
           context.read<CanvasCubit>().deleteText(index);
         } else if (result != null) {
@@ -51,6 +51,7 @@ class EditTextDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
     final controller = TextEditingController(text: initialText);
 
     return Dialog(
@@ -71,16 +72,23 @@ class EditTextDialog extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 16),
-            TextField(
-              controller: controller,
-              decoration: InputDecoration(
-                labelText: 'Text',
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: const BorderSide(color: Colors.purple, width: 2),
+            Form(
+              key: formKey,
+              child: TextFormField(
+                controller: controller,
+                validator: (value) => (value == null || value.trim().isEmpty)
+                    ? 'Text cannot be empty'
+                    : null,
+                decoration: InputDecoration(
+                  labelText: 'Text',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide:
+                        const BorderSide(color: Colors.purple, width: 2),
+                  ),
                 ),
               ),
             ),
@@ -101,14 +109,7 @@ class EditTextDialog extends StatelessWidget {
                     final trimmedText = controller.text.trim();
 
                     if (trimmedText.isEmpty) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text('Text field cannot be empty'),
-                          backgroundColor: Colors.redAccent,
-                          behavior: SnackBarBehavior.fixed,
-                          duration: Duration(seconds: 2),
-                        ),
-                      );
+                      formKey.currentState?.validate();
                     } else {
                       Navigator.pop(context, trimmedText);
                     }


### PR DESCRIPTION
### What kind of change does this PR introduce?

UX Improvement / Bugfix

### Issue Number:

Fixes #28

### Snapshots/Videos:

** Before: **

- Error shown via Snackbar (often hidden behind modal)

** After: **

- Error shown inline, under the text field, with red border.

### Summary

Previously, when a user attempted to save an empty string while editing a text item, the app used a `Snackbar `to show the error. However, since the edit dialog is a modal, the Snackbar often appeared behind it and went unnoticed.

This PR replaces that approach with inline validation using `TextFormField` inside a `Form `widget. If the user submits an empty string, the dialog now highlights the error right below the input, providing a clearer, more immediate UX.

### Does this PR introduce a breaking change?

No

### Other information

- Introduced `GlobalKey<FormState>` for form validation control.
- Migrated from `TextField` to `TextFormField`.
- Dialog does not close unless the input passes validation.

### Have you read the [contributing guide](https://github.com/may-tas/TextEditingApp/blob/main/CONTRIBUTING.md) , [README.md](https://github.com/may-tas/TextEditingApp/blob/main/README.md) , [code of conduct](https://github.com/may-tas/TextEditingApp/blob/main/CODE_OF_CONDUCT.md)?

Yes