### PR TITLE
Added Clear Formatting/Restore Default Button

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.3.0" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/lib/ui/widgets/font_controls.dart
+++ b/lib/ui/widgets/font_controls.dart
@@ -34,9 +34,56 @@ class FontControls extends StatelessWidget {
             _buildFontFamilyControls(context),
             const SizedBox(width: 25),
             _buildColorControls(context),
+            const SizedBox(width: 25), // Add spacing for the new button
+            _buildClearFormatButton(context), // Call your new function here
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildClearFormatButton(BuildContext context) {
+    return BlocBuilder<CanvasCubit, CanvasState>(
+      buildWhen: (previous, current) =>
+      previous.selectedTextItemIndex != current.selectedTextItemIndex,
+      builder: (context, state) {
+        final selectedIndex = state.selectedTextItemIndex;
+        final isDisabled =
+            selectedIndex == null || selectedIndex >= state.textItems.length;
+
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const Text('Restore Default',
+                style: TextStyle(fontWeight: FontWeight.w600, fontSize: 14)),
+            const SizedBox(width: 12),
+            Container(
+              decoration: BoxDecoration(
+                color: Colors.grey[100],
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.grey[300]!),
+              ),
+              // re-using Button-style for consistent UI
+              child: _buildStyleButton(
+                icon: Icons.layers_clear,
+                isSelected: false, // This button is never in a "selected" state.
+                onPressed: isDisabled
+                    ? null
+                    : () {
+                  final cubit = context.read<CanvasCubit>();
+                  // Reset all properties to their default values.
+                  cubit.changeFontWeight(selectedIndex, FontWeight.normal);
+                  cubit.changeFontStyle(selectedIndex, FontStyle.normal);
+                  cubit.changeTextColor(selectedIndex, Colors.white);
+                  cubit.changeFontFamily(selectedIndex, 'Arial');
+                  cubit.changeFontSize(selectedIndex, 16.0);
+                },
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 
@@ -116,7 +163,7 @@ class FontControls extends StatelessWidget {
                                 selectedIndex, FontStyle.normal);
                             context.read<CanvasCubit>().changeFontWeight(
                                 selectedIndex, FontWeight.normal);
-                          },
+                            },
                   ),
                 ],
               ),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please fill out the information below to help reviewers understand the changes.
-->

### 🚀 What does this PR introduce?
A new **Clear Formatting** button feature.

<!-- Examples: Feature addition, bugfix, refactor, documentation, etc. -->

### 🔗 Related Issue

Fixes #34<!--Paste issue number here-->

<!-- If applicable, attach screenshots or screen recordings to illustrate the update. -->

### 📝 Summary

This PR adds a **Clear Formatting** button to simplify text restoration. Users often apply multiple formatting styles to text, and manually undoing each can be tedious. The newly added button offers a quick reset, restoring default text properties:

- Font family → `Arial`
- Font size → `16px`
- Font style → normal (removes bold/italic/underline)
- Text color → `white`

This enhancement improves usability, especially when users want to revert to a clean slate with minimal effort.

### 📖 Checklist

Have you read and followed the repository's guidelines?

- [x] CONTRIBUTING.md  
- [x] README.md  
- [x] CODE_OF_CONDUCT.md