### PR TITLE
 Toggle for Background Color Tray  issue solution 🎨

### DIFF
--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -5,7 +5,7 @@ import 'canvas_state.dart';
 
 class CanvasCubit extends Cubit<CanvasState> {
   CanvasCubit() : super(CanvasState.initial());
-
+  
   //method to select text
   void selectText(int index) {
     if (index >= 0 && index < state.textItems.length) {

--- a/lib/ui/screens/canvas_screen.dart
+++ b/lib/ui/screens/canvas_screen.dart
@@ -7,9 +7,16 @@ import '../widgets/editable_text_widget.dart';
 import '../widgets/font_controls.dart';
 import '../widgets/background_color_tray.dart';
 
-class CanvasScreen extends StatelessWidget {
+class CanvasScreen extends StatefulWidget {
   const CanvasScreen({super.key});
 
+  @override
+  State<CanvasScreen> createState() => _CanvasScreenState();
+}
+
+class _CanvasScreenState extends State<CanvasScreen>  {
+  
+  bool showTray = false;
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -32,6 +39,14 @@ class CanvasScreen extends StatelessWidget {
           onPressed: () => context.read<CanvasCubit>().clearCanvas(),
         ),
         actions: [
+          IconButton(
+            tooltip :'change background color',
+            icon :const Icon(
+              Icons.color_lens,
+              color: Colors.black54,
+            ),
+            onPressed: () => setState(() => showTray = !showTray),
+          ),
           IconButton(
             tooltip: "Undo",
             icon: const Icon(Icons.undo, color: Colors.black54),
@@ -85,9 +100,12 @@ class CanvasScreen extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Container(
+            Visibility(
+            visible: showTray,
+            child: Container(
               color: Colors.white,
               child: const BackgroundColorTray(),
+            ),
             ),
             const FontControls(),
           ],

--- a/lib/ui/widgets/font_controls.dart
+++ b/lib/ui/widgets/font_controls.dart
@@ -314,6 +314,7 @@ class FontControls extends StatelessWidget {
                               title: const Text('Pick a color'),
                               showColorCode: true,
                               showRecentColors: false,
+                              backgroundColor: Colors.white, 
                             );
 
                             if (!context.mounted) return;

--- a/lib/ui/widgets/font_controls.dart
+++ b/lib/ui/widgets/font_controls.dart
@@ -315,6 +315,10 @@ class FontControls extends StatelessWidget {
                               showColorCode: true,
                               showRecentColors: false,
                               backgroundColor: Colors.white, 
+                              constraints: const BoxConstraints(
+                                  minHeight: 400,
+                                  minWidth: 300,
+                                ),
                             );
 
                             if (!context.mounted) return;

--- a/lib/ui/widgets/font_controls.dart
+++ b/lib/ui/widgets/font_controls.dart
@@ -1,3 +1,4 @@
+import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -45,7 +46,7 @@ class FontControls extends StatelessWidget {
   Widget _buildClearFormatButton(BuildContext context) {
     return BlocBuilder<CanvasCubit, CanvasState>(
       buildWhen: (previous, current) =>
-      previous.selectedTextItemIndex != current.selectedTextItemIndex,
+          previous.selectedTextItemIndex != current.selectedTextItemIndex,
       builder: (context, state) {
         final selectedIndex = state.selectedTextItemIndex;
         final isDisabled =
@@ -67,18 +68,20 @@ class FontControls extends StatelessWidget {
               // re-using Button-style for consistent UI
               child: _buildStyleButton(
                 icon: Icons.layers_clear,
-                isSelected: false, // This button is never in a "selected" state.
+                isSelected:
+                    false, // This button is never in a "selected" state.
                 onPressed: isDisabled
                     ? null
                     : () {
-                  final cubit = context.read<CanvasCubit>();
-                  // Reset all properties to their default values.
-                  cubit.changeFontWeight(selectedIndex, FontWeight.normal);
-                  cubit.changeFontStyle(selectedIndex, FontStyle.normal);
-                  cubit.changeTextColor(selectedIndex, Colors.white);
-                  cubit.changeFontFamily(selectedIndex, 'Arial');
-                  cubit.changeFontSize(selectedIndex, 16.0);
-                },
+                        final cubit = context.read<CanvasCubit>();
+                        // Reset all properties to their default values.
+                        cubit.changeFontWeight(
+                            selectedIndex, FontWeight.normal);
+                        cubit.changeFontStyle(selectedIndex, FontStyle.normal);
+                        cubit.changeTextColor(selectedIndex, Colors.white);
+                        cubit.changeFontFamily(selectedIndex, 'Arial');
+                        cubit.changeFontSize(selectedIndex, 16.0);
+                      },
               ),
             ),
           ],
@@ -163,7 +166,7 @@ class FontControls extends StatelessWidget {
                                 selectedIndex, FontStyle.normal);
                             context.read<CanvasCubit>().changeFontWeight(
                                 selectedIndex, FontWeight.normal);
-                            },
+                          },
                   ),
                 ],
               ),
@@ -270,33 +273,57 @@ class FontControls extends StatelessWidget {
                 border: Border.all(color: Colors.grey[300]!),
               ),
               child: Row(
-                children: colors.map((color) {
-                  final isSelected = selectedColor == color;
-                  return GestureDetector(
-                    onTap: isDisabled
-                        ? null
-                        : () => context
-                            .read<CanvasCubit>()
-                            .changeTextColor(selectedIndex, color),
-                    child: Container(
-                      width: 28,
-                      height: 28,
-                      margin: const EdgeInsets.symmetric(horizontal: 4),
-                      decoration: BoxDecoration(
-                        color: color,
-                        shape: BoxShape.circle,
-                        border: Border.all(
-                          color: isSelected
-                              ? Colors.blueAccent
-                              : (color == Colors.white
-                                  ? Colors.grey[400]!
-                                  : Colors.transparent),
-                          width: isSelected ? 3 : 1,
+                children: [
+                  ...colors.map((color) {
+                    final isSelected = selectedColor == color;
+                    return GestureDetector(
+                      onTap: isDisabled
+                          ? null
+                          : () => context
+                              .read<CanvasCubit>()
+                              .changeTextColor(selectedIndex, color),
+                      child: Container(
+                        width: 28,
+                        height: 28,
+                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                        decoration: BoxDecoration(
+                          color: color,
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color: isSelected
+                                ? Colors.blueAccent
+                                : (color == Colors.white
+                                    ? Colors.grey[400]!
+                                    : Colors.transparent),
+                            width: isSelected ? 3 : 1,
+                          ),
                         ),
                       ),
-                    ),
-                  );
-                }).toList(),
+                    );
+                  }),
+                  //More Colors Button ^_^
+                  IconButton(
+                    icon: const Icon(Icons.more_horiz, color: Colors.black54),
+                    tooltip: 'More colors',
+                    onPressed: isDisabled
+                        ? null
+                        : () async {
+                            final pickedColor = await showColorPickerDialog(
+                              context,
+                              selectedColor,
+                              title: const Text('Pick a color'),
+                              showColorCode: true,
+                              showRecentColors: false,
+                            );
+
+                            if (!context.mounted) return;
+
+                            context
+                                .read<CanvasCubit>()
+                                .changeTextColor(selectedIndex, pickedColor);
+                          },
+                  ),
+                ],
               ),
             ),
           ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,14 +158,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.6"
-  flutter_colorpicker:
-    dependency: "direct main"
-    description:
-      name: flutter_colorpicker
-      sha256: "969de5f6f9e2a570ac660fb7b501551451ea2a1ab9e2097e89475f60e07816ea"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  flex_color_picker:
+    dependency: "direct main"
+    description:
+      name: flex_color_picker
+      sha256: "8f753a1a026a13ea5cc5eddbae3ceb886f2537569ab2e5208efb1e3bb5af72ff"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.1"
+  flex_seed_scheme:
+    dependency: transitive
+    description:
+      name: flex_seed_scheme
+      sha256: b06d8b367b84cbf7ca5c5603c858fa5edae88486c4e4da79ac1044d73b6c62ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -142,6 +158,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.6"
+  flutter_colorpicker:
+    dependency: "direct main"
+    description:
+      name: flutter_colorpicker
+      sha256: "969de5f6f9e2a570ac660fb7b501551451ea2a1ab9e2097e89475f60e07816ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -399,4 +423,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   flutter_bloc: ^8.1.6
+  flutter_colorpicker: ^1.1.0
+  flex_color_picker: ^3.7.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,6 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   flutter_bloc: ^8.1.6
-  flutter_colorpicker: ^1.1.0
   flex_color_picker: ^3.7.1
 
 dev_dependencies:


### PR DESCRIPTION
### What kind of change does this PR introduce?  

This PR addresses a key UI issue related to unused screen space and an uncomfortable user interface.  
I implemented a **palette icon** that allows users to toggle (show/hide) the background color bar, enabling them to easily change the canvas background color. 🎨  

### Issue Number: #22  

### Snapshots/Videos:  ✅


https://github.com/user-attachments/assets/38fdc3d3-3ccf-45a1-bf18-b9bbfd1cf606


### Summary  😊

This PR enhances the user experience by making the interface cleaner and more interactive.  
Thank you for assigning me this task – it was an interesting and valuable issue to work on. 🚀  
