### PR TITLE
Feat: Implement horizontally scrollable canvas for text items and solved the overlapping new text problem

### DIFF
--- a/lib/cubit/canvas_state.dart
+++ b/lib/cubit/canvas_state.dart
@@ -5,27 +5,33 @@ class CanvasState {
   final List<TextItem> textItems;
   final List<CanvasState> history;
   final List<CanvasState> future;
-  final Color backgroundColor; // Added background color
+  final Color backgroundColor;
   final int? selectedTextItemIndex;
-  final bool isTrayShown ;
+  final bool isTrayShown;
+  final double canvasWidth;
+  final double canvasHeight;
 
   const CanvasState({
     required this.textItems,
     required this.history,
     required this.future,
-    this.backgroundColor = const Color(0xFF1A1A1A), // Default value
+    this.backgroundColor = const Color(0xFF1A1A1A),
     this.selectedTextItemIndex,
     this.isTrayShown = false,
+    required this.canvasWidth,
+    required this.canvasHeight,
   });
 
   factory CanvasState.initial() {
     return const CanvasState(
-      textItems: [], 
-      history: [], 
+      textItems: [],
+      history: [],
       future: [],
-      backgroundColor: Color(0xFF1A1A1A), // Default dark background
-      selectedTextItemIndex: null);
-
+      backgroundColor: Color(0xFF1A1A1A),
+      selectedTextItemIndex: null,
+      canvasWidth: 0,
+      canvasHeight: 0,
+    );
   }
 
   CanvasState copyWith({
@@ -35,7 +41,9 @@ class CanvasState {
     Color? backgroundColor,
     int? selectedTextItemIndex,
     bool deselect = false,
-    bool isTrayShown = false
+    bool? isTrayShown,
+    double? canvasWidth,
+    double? canvasHeight,
   }) {
     return CanvasState(
       textItems: textItems ?? this.textItems,
@@ -43,7 +51,9 @@ class CanvasState {
       future: future ?? this.future,
       backgroundColor: backgroundColor ?? this.backgroundColor,
       selectedTextItemIndex: deselect ? null : selectedTextItemIndex ?? this.selectedTextItemIndex,
-      isTrayShown: deselect ? false : isTrayShown
+      isTrayShown: deselect ? false : (isTrayShown ?? this.isTrayShown),
+      canvasWidth: canvasWidth ?? this.canvasWidth,
+      canvasHeight: canvasHeight ?? this.canvasHeight,
     );
   }
 }

--- a/lib/ui/widgets/editable_text_widget.dart
+++ b/lib/ui/widgets/editable_text_widget.dart
@@ -38,7 +38,6 @@ class EditableTextWidget extends StatelessWidget {
           context.read<CanvasCubit>().editText(index, result);
         }
       },
-      // 4. onDoubleTap handler is now gone
       child: Text(
         textItem.text,
         style: GoogleFonts.getFont(
@@ -47,7 +46,8 @@ class EditableTextWidget extends StatelessWidget {
           fontWeight: textItem.fontWeight,
           fontSize: textItem.fontSize,
           color: textItem.color,
-          backgroundColor: isSelected ? Colors.yellow.withAlpha((0.3 * 255).toInt()) : null,
+          backgroundColor:
+              isSelected ? Colors.yellow.withAlpha((0.3 * 255).toInt()) : null,
         ),
       ),
     );


### PR DESCRIPTION
**Description**

This PR resolves the issue of new text items overlapping or being placed off-screen. It introduces a horizontally scrollable canvas that dynamically expands as new columns of text are needed, ensuring a predictable layout and infinite space for creativity.

---

**Resolves:** #65

---

**Changes Made**

*   **`canvas_state.dart`**: Added `canvasWidth` and `canvasHeight` to the state to track the canvas dimensions.
*   **`canvas_cubit.dart`**: Reworked the `addText` logic to place items in a grid. The cubit now expands the `canvasWidth` when a new column is created.
*   **`canvas_screen.dart`**:
    *   Converted to a `StatefulWidget` to manage a `ScrollController`.
    *   Wrapped the canvas in a `SingleChildScrollView`.
    *   Added a `BlocListener` to auto-scroll to the end when the canvas expands, showing the user the new content immediately.

---

**How to Test**

1.  Run the application.
2.  Add new text items repeatedly.
3.  **Expected:**
    *   Text appears in a vertical column.
    *   When the column fills up, a new column is created to the right.
    *   A horizontal scrollbar appears.
    *   The view automatically scrolls to show the new column.