### PR TITLE
Added the Feature to Upload Background Image #76 Level 2

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <application
         android:label="Texterra"
         android:name="${applicationName}"

--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -1,14 +1,20 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:super_clipboard/super_clipboard.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as path;
 import 'package:texterra/utils/custom_snackbar.dart';
 import '../models/text_item_model.dart';
 import 'canvas_state.dart';
 
 class CanvasCubit extends Cubit<CanvasState> {
+  final ImagePicker _imagePicker = ImagePicker();
+
   CanvasCubit() : super(CanvasState.initial());
 
   //method to toggle the color tray
@@ -79,6 +85,95 @@ class CanvasCubit extends Cubit<CanvasState> {
   // method to change background color
   void changeBackgroundColor(Color color) {
     _updateState(backgroundColor: color);
+  }
+
+  // NEW: Method to upload background image from gallery
+  Future<void> uploadBackgroundImage() async {
+    try {
+      final XFile? image = await _imagePicker.pickImage(
+        source: ImageSource.gallery,
+        imageQuality: 85, // Compress to reduce file size
+      );
+
+      if (image == null) return; // User cancelled selection
+
+      // Save image to app's document directory
+      final savedPath = await _saveImageToAppDirectory(image);
+      
+      if (savedPath != null) {
+        _updateState(backgroundImagePath: savedPath);
+        emit(state.copyWith(message: 'Background image uploaded successfully!'));
+      }
+    } catch (e) {
+      print('Error uploading background image: $e');
+      emit(state.copyWith(message: 'Error uploading image: $e'));
+    }
+  }
+
+  // NEW: Method to take photo for background
+  Future<void> takePhotoForBackground() async {
+    try {
+      final XFile? image = await _imagePicker.pickImage(
+        source: ImageSource.camera,
+        imageQuality: 85, // Compress to reduce file size
+      );
+
+      if (image == null) return; // User cancelled
+
+      // Save image to app's document directory
+      final savedPath = await _saveImageToAppDirectory(image);
+      
+      if (savedPath != null) {
+        _updateState(backgroundImagePath: savedPath);
+        emit(state.copyWith(message: 'Background photo captured successfully!'));
+      }
+    } catch (e) {
+      print('Error taking photo for background: $e');
+      emit(state.copyWith(message: 'Error taking photo: $e'));
+    }
+  }
+
+  // NEW: Method to remove background image
+  void removeBackgroundImage() {
+    // Delete the old image file if it exists
+    if (state.backgroundImagePath != null) {
+      _deleteImageFile(state.backgroundImagePath!);
+    }
+    
+    _updateState(clearBackgroundImage: true);
+    emit(state.copyWith(message: 'Background image removed'));
+  }
+
+  // NEW: Helper method to save image to app directory
+  Future<String?> _saveImageToAppDirectory(XFile image) async {
+    try {
+      final appDir = await getApplicationDocumentsDirectory();
+      final fileName = 'bg_${DateTime.now().millisecondsSinceEpoch}${path.extension(image.path)}';
+      final savedPath = path.join(appDir.path, fileName);
+      
+      // Copy the file to app directory
+      final File imageFile = File(image.path);
+      await imageFile.copy(savedPath);
+      
+      print('Image saved to: $savedPath');
+      return savedPath;
+    } catch (e) {
+      print('Error saving image: $e');
+      return null;
+    }
+  }
+
+  // NEW: Helper method to delete image file
+  Future<void> _deleteImageFile(String imagePath) async {
+    try {
+      final file = File(imagePath);
+      if (await file.exists()) {
+        await file.delete();
+        print('Deleted image file: $imagePath');
+      }
+    } catch (e) {
+      print('Error deleting image file: $e');
+    }
   }
 
   // method to editText and emit changes
@@ -156,6 +251,11 @@ class CanvasCubit extends Cubit<CanvasState> {
 
   // method to empty the canvas
   void clearCanvas() {
+    // Delete the background image if it exists
+    if (state.backgroundImagePath != null) {
+      _deleteImageFile(state.backgroundImagePath!);
+    }
+    
     emit(
       state.copyWith(
         textItems: [],
@@ -163,7 +263,8 @@ class CanvasCubit extends Cubit<CanvasState> {
         future: [],
         selectedTextItemIndex: null,
         deselect: true,
-        clearCurrentPageName: true, // Clear the current page name when clearing canvas
+        clearCurrentPageName: true,
+        clearBackgroundImage: true,
       ),
     );
   }
@@ -172,10 +273,14 @@ class CanvasCubit extends Cubit<CanvasState> {
   void _updateState({
     List<TextItem>? textItems,
     Color? backgroundColor,
+    String? backgroundImagePath,
+    bool clearBackgroundImage = false,
   }) {
     final newState = state.copyWith(
       textItems: textItems ?? state.textItems,
       backgroundColor: backgroundColor,
+      backgroundImagePath: backgroundImagePath,
+      clearBackgroundImage: clearBackgroundImage,
       history: [...state.history, state],
       future: [],
     );
@@ -194,12 +299,12 @@ class CanvasCubit extends Cubit<CanvasState> {
 
   // ==================== SAVE/LOAD FUNCTIONALITY ====================
 
-  // Save current canvas state
+  // UPDATED: Save current canvas state (now includes background image)
   Future<void> savePage(String pageName) async {
     try {
       final prefs = await SharedPreferences.getInstance();
 
-      print('🔄 Saving page: $pageName'); // Debug log
+      print('🔄 Saving page: $pageName');
 
       // Convert current state to JSON
       final pageData = {
@@ -215,28 +320,29 @@ class CanvasCubit extends Cubit<CanvasState> {
           'isUnderlined': item.isUnderlined,
         }).toList(),
         'backgroundColor': state.backgroundColor.value,
+        'backgroundImagePath': state.backgroundImagePath, // Save background image path
         'timestamp': DateTime.now().millisecondsSinceEpoch,
       };
 
-      print('📦 Page data: ${jsonEncode(pageData)}'); // Debug log
+      print('📦 Page data: ${jsonEncode(pageData)}');
 
       // Save the page data
       final saved = await prefs.setString('page_$pageName', jsonEncode(pageData));
-      print('💾 Page saved successfully: $saved'); // Debug log
+      print('💾 Page saved successfully: $saved');
 
       // Update saved pages list
       List<String> savedPages = prefs.getStringList('saved_pages') ?? [];
-      print('📋 Current saved pages before: $savedPages'); // Debug log
+      print('📋 Current saved pages before: $savedPages');
 
       if (!savedPages.contains(pageName)) {
         savedPages.add(pageName);
         final listSaved = await prefs.setStringList('saved_pages', savedPages);
-        print('📝 Updated saved pages list: $listSaved -> $savedPages'); // Debug log
+        print('📝 Updated saved pages list: $listSaved -> $savedPages');
       }
 
       // Verify the save
       final verification = prefs.getStringList('saved_pages');
-      print('✅ Verification - saved pages: $verification'); // Debug log
+      print('✅ Verification - saved pages: $verification');
 
       // Set the current page name and emit success message
       emit(state.copyWith(
@@ -244,8 +350,8 @@ class CanvasCubit extends Cubit<CanvasState> {
         message: 'Page "$pageName" saved successfully!',
       ));
     } catch (e, stackTrace) {
-      print('❌ Error saving page: $e'); // Debug log
-      print('Stack trace: $stackTrace'); // Debug log
+      print('❌ Error saving page: $e');
+      print('Stack trace: $stackTrace');
       emit(state.copyWith(
         message: 'Error saving page: $e',
       ));
@@ -262,24 +368,24 @@ class CanvasCubit extends Cubit<CanvasState> {
     return false; // Indicates that dialog should be shown
   }
 
-  // Load a saved page
+  // UPDATED: Load a saved page (now includes background image)
   Future<void> loadPage(String pageName) async {
     try {
-      print('🔄 Loading page: $pageName'); // Debug log
+      print('🔄 Loading page: $pageName');
 
       final prefs = await SharedPreferences.getInstance();
       final pageDataString = prefs.getString('page_$pageName');
 
-      print('📦 Raw page data: $pageDataString'); // Debug log
+      print('📦 Raw page data: $pageDataString');
 
       if (pageDataString == null) {
-        print('❌ Page not found: $pageName'); // Debug log
+        print('❌ Page not found: $pageName');
         emit(state.copyWith(message: 'Page "$pageName" not found'));
         return;
       }
 
       final pageData = jsonDecode(pageDataString);
-      print('📋 Decoded page data: $pageData'); // Debug log
+      print('📋 Decoded page data: $pageData');
 
       final textItems = (pageData['textItems'] as List).map((item) {
         return TextItem(
@@ -295,35 +401,56 @@ class CanvasCubit extends Cubit<CanvasState> {
         );
       }).toList();
 
-      print('✅ Successfully loaded ${textItems.length} text items'); // Debug log
+      // Load background image path if it exists
+      final backgroundImagePath = pageData['backgroundImagePath'] as String?;
+      
+      // Verify the background image file still exists
+      String? validImagePath;
+      if (backgroundImagePath != null) {
+        final imageFile = File(backgroundImagePath);
+        if (await imageFile.exists()) {
+          validImagePath = backgroundImagePath;
+        } else {
+          print('⚠️ Background image file not found: $backgroundImagePath');
+        }
+      }
+
+      print('✅ Successfully loaded ${textItems.length} text items');
 
       emit(CanvasState(
         textItems: textItems,
         backgroundColor: Color(pageData['backgroundColor']),
+        backgroundImagePath: validImagePath,
         selectedTextItemIndex: null,
         message: 'Page "$pageName" loaded successfully!',
         history: [],
         future: [],
-        currentPageName: pageName, // Set the current page name
+        currentPageName: pageName,
       ));
     } catch (e, stackTrace) {
-      print('❌ Error loading page: $e'); // Debug log
-      print('Stack trace: $stackTrace'); // Debug log
+      print('❌ Error loading page: $e');
+      print('Stack trace: $stackTrace');
       emit(state.copyWith(
         message: 'Error loading page: $e',
       ));
     }
   }
 
-  // Create new page (clears current page name)
+  // UPDATED: Create new page (clears current page name and background image)
   void createNewPage() {
+    // Delete the current background image if it exists
+    if (state.backgroundImagePath != null) {
+      _deleteImageFile(state.backgroundImagePath!);
+    }
+    
     emit(state.copyWith(
       textItems: [],
       backgroundColor: Colors.black,
       selectedTextItemIndex: null,
       history: [],
       future: [],
-      clearCurrentPageName: true, // Clear the current page name
+      clearCurrentPageName: true,
+      clearBackgroundImage: true,
       message: 'New page created',
     ));
   }
@@ -331,44 +458,60 @@ class CanvasCubit extends Cubit<CanvasState> {
   // Get list of saved pages
   Future<List<String>> getSavedPages() async {
     try {
-      print('🔄 Getting saved pages...'); // Debug log
+      print('🔄 Getting saved pages...');
 
       final prefs = await SharedPreferences.getInstance();
       final savedPages = prefs.getStringList('saved_pages') ?? [];
 
-      print('📋 Found saved pages: $savedPages'); // Debug log
+      print('📋 Found saved pages: $savedPages');
 
       // Also check what keys exist in SharedPreferences
       final allKeys = prefs.getKeys();
       final pageKeys = allKeys.where((key) => key.startsWith('page_')).toList();
-      print('🔑 All page keys in storage: $pageKeys'); // Debug log
+      print('🔑 All page keys in storage: $pageKeys');
 
       return savedPages;
     } catch (e, stackTrace) {
-      print('❌ Error getting saved pages: $e'); // Debug log
-      print('Stack trace: $stackTrace'); // Debug log
+      print('❌ Error getting saved pages: $e');
+      print('Stack trace: $stackTrace');
       return [];
     }
   }
 
-  // Delete a saved page
+  // UPDATED: Delete a saved page (now also cleans up background image files)
   Future<void> deletePage(String pageName) async {
     try {
-      print('🗑️ Deleting page: $pageName'); // Debug log
+      print('🗑️ Deleting page: $pageName');
 
       final prefs = await SharedPreferences.getInstance();
 
+      // Get page data to check for background image before deleting
+      final pageDataString = prefs.getString('page_$pageName');
+      if (pageDataString != null) {
+        try {
+          final pageData = jsonDecode(pageDataString);
+          final backgroundImagePath = pageData['backgroundImagePath'] as String?;
+          
+          // Delete the background image file if it exists
+          if (backgroundImagePath != null) {
+            await _deleteImageFile(backgroundImagePath);
+          }
+        } catch (e) {
+          print('⚠️ Error reading page data for cleanup: $e');
+        }
+      }
+
       // Remove the page data
       final dataRemoved = await prefs.remove('page_$pageName');
-      print('📦 Page data removed: $dataRemoved'); // Debug log
+      print('📦 Page data removed: $dataRemoved');
 
       // Update the saved pages list
       List<String> savedPages = prefs.getStringList('saved_pages') ?? [];
-      print('📋 Saved pages before removal: $savedPages'); // Debug log
+      print('📋 Saved pages before removal: $savedPages');
 
       savedPages.remove(pageName);
       final listUpdated = await prefs.setStringList('saved_pages', savedPages);
-      print('📝 Saved pages after removal: $savedPages, updated: $listUpdated'); // Debug log
+      print('📝 Saved pages after removal: $savedPages, updated: $listUpdated');
 
       // If the deleted page is the current page, clear the current page name
       if (state.currentPageName == pageName) {
@@ -382,8 +525,8 @@ class CanvasCubit extends Cubit<CanvasState> {
         ));
       }
     } catch (e, stackTrace) {
-      print('❌ Error deleting page: $e'); // Debug log
-      print('Stack trace: $stackTrace'); // Debug log
+      print('❌ Error deleting page: $e');
+      print('Stack trace: $stackTrace');
       emit(state.copyWith(
         message: 'Error deleting page: $e',
       ));
@@ -393,13 +536,13 @@ class CanvasCubit extends Cubit<CanvasState> {
   // Get page preview data (for thumbnails or previews)
   Future<Map<String, dynamic>?> getPagePreview(String pageName) async {
     try {
-      print('🔍 Getting preview for page: $pageName'); // Debug log
+      print('🔍 Getting preview for page: $pageName');
 
       final prefs = await SharedPreferences.getInstance();
       final pageDataString = prefs.getString('page_$pageName');
 
       if (pageDataString == null) {
-        print('❌ No preview data found for: $pageName'); // Debug log
+        print('❌ No preview data found for: $pageName');
         return null;
       }
 
@@ -408,15 +551,16 @@ class CanvasCubit extends Cubit<CanvasState> {
         'name': pageName,
         'textCount': (pageData['textItems'] as List).length,
         'backgroundColor': Color(pageData['backgroundColor']),
+        'backgroundImagePath': pageData['backgroundImagePath'], // Include background image
         'timestamp': pageData['timestamp'],
         'lastModified': DateTime.fromMillisecondsSinceEpoch(pageData['timestamp']),
       };
 
-      print('✅ Preview generated for $pageName: ${preview['textCount']} items'); // Debug log
+      print('✅ Preview generated for $pageName: ${preview['textCount']} items');
       return preview;
     } catch (e, stackTrace) {
-      print('❌ Error getting preview for $pageName: $e'); // Debug log
-      print('Stack trace: $stackTrace'); // Debug log
+      print('❌ Error getting preview for $pageName: $e');
+      print('Stack trace: $stackTrace');
       return null;
     }
   }
@@ -426,25 +570,49 @@ class CanvasCubit extends Cubit<CanvasState> {
     emit(state.copyWith(message: null));
   }
 
-  // Debug method to clear all saved data (useful for testing)
+  // UPDATED: Debug method to clear all saved data (now also cleans up image files)
   Future<void> clearAllSavedData() async {
     try {
       final prefs = await SharedPreferences.getInstance();
       final allKeys = prefs.getKeys();
-      final pageKeys = allKeys.where((key) => key.startsWith('page_') || key == 'saved_pages');
+      final pageKeys = allKeys.where((key) => key.startsWith('page_'));
 
+      // Clean up all background image files
       for (final key in pageKeys) {
+        final pageDataString = prefs.getString(key);
+        if (pageDataString != null) {
+          try {
+            final pageData = jsonDecode(pageDataString);
+            final backgroundImagePath = pageData['backgroundImagePath'] as String?;
+            if (backgroundImagePath != null) {
+              await _deleteImageFile(backgroundImagePath);
+            }
+          } catch (e) {
+            print('⚠️ Error cleaning up image for $key: $e');
+          }
+        }
+      }
+
+      // Clear all saved page data
+      final keysToRemove = allKeys.where((key) => key.startsWith('page_') || key == 'saved_pages');
+      for (final key in keysToRemove) {
         await prefs.remove(key);
       }
 
-      print('🧹 Cleared all saved data: $pageKeys'); // Debug log
+      // Also clear current background image
+      if (state.backgroundImagePath != null) {
+        await _deleteImageFile(state.backgroundImagePath!);
+      }
+
+      print('🧹 Cleared all saved data: $keysToRemove');
 
       emit(state.copyWith(
         message: 'All saved data cleared!',
         clearCurrentPageName: true,
+        clearBackgroundImage: true,
       ));
     } catch (e) {
-      print('❌ Error clearing saved data: $e'); // Debug log
+      print('❌ Error clearing saved data: $e');
     }
   }
 

--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -61,7 +61,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     );
   }
 
-  // FIX: Reset all formatting
+  // Reset all formatting
   void resetFormatting(int index) {
     final updatedItems = List<TextItem>.from(state.textItems);
     updatedItems[index] = updatedItems[index].copyWith(
@@ -87,7 +87,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     _updateState(backgroundColor: color);
   }
 
-  // NEW: Method to upload background image from gallery
+  // Method to upload background image from gallery
   Future<void> uploadBackgroundImage() async {
     try {
       final XFile? image = await _imagePicker.pickImage(
@@ -110,7 +110,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     }
   }
 
-  // NEW: Method to take photo for background
+  // Method to take photo for background
   Future<void> takePhotoForBackground() async {
     try {
       final XFile? image = await _imagePicker.pickImage(
@@ -133,7 +133,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     }
   }
 
-  // NEW: Method to remove background image
+  // Method to remove background image
   void removeBackgroundImage() {
     // Delete the old image file if it exists
     if (state.backgroundImagePath != null) {
@@ -144,7 +144,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     emit(state.copyWith(message: 'Background image removed'));
   }
 
-  // NEW: Helper method to save image to app directory
+  // Helper method to save image to app directory
   Future<String?> _saveImageToAppDirectory(XFile image) async {
     try {
       final appDir = await getApplicationDocumentsDirectory();
@@ -163,7 +163,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     }
   }
 
-  // NEW: Helper method to delete image file
+  // Helper method to delete image file
   Future<void> _deleteImageFile(String imagePath) async {
     try {
       final file = File(imagePath);
@@ -269,7 +269,6 @@ class CanvasCubit extends Cubit<CanvasState> {
     );
   }
 
-  // update state with this
   void _updateState({
     List<TextItem>? textItems,
     Color? backgroundColor,
@@ -297,16 +296,12 @@ class CanvasCubit extends Cubit<CanvasState> {
         deselect: true));
   }
 
-  // ==================== SAVE/LOAD FUNCTIONALITY ====================
-
-  // UPDATED: Save current canvas state (now includes background image)
   Future<void> savePage(String pageName) async {
     try {
       final prefs = await SharedPreferences.getInstance();
 
       print('🔄 Saving page: $pageName');
 
-      // Convert current state to JSON
       final pageData = {
         'textItems': state.textItems.map((item) => {
           'text': item.text,
@@ -368,7 +363,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     return false; // Indicates that dialog should be shown
   }
 
-  // UPDATED: Load a saved page (now includes background image)
+  // Load a saved page (now includes background image)
   Future<void> loadPage(String pageName) async {
     try {
       print('🔄 Loading page: $pageName');
@@ -436,7 +431,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     }
   }
 
-  // UPDATED: Create new page (clears current page name and background image)
+  // Create new page (clears current page name and background image)
   void createNewPage() {
     // Delete the current background image if it exists
     if (state.backgroundImagePath != null) {
@@ -478,7 +473,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     }
   }
 
-  // UPDATED: Delete a saved page (now also cleans up background image files)
+  // Delete a saved page (now also cleans up background image files)
   Future<void> deletePage(String pageName) async {
     try {
       print('🗑️ Deleting page: $pageName');
@@ -570,7 +565,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     emit(state.copyWith(message: null));
   }
 
-  // UPDATED: Debug method to clear all saved data (now also cleans up image files)
+  // Debug method to clear all saved data (now also cleans up image files)
   Future<void> clearAllSavedData() async {
     try {
       final prefs = await SharedPreferences.getInstance();

--- a/lib/cubit/canvas_state.dart
+++ b/lib/cubit/canvas_state.dart
@@ -6,7 +6,7 @@ class CanvasState {
   final List<CanvasState> history;
   final List<CanvasState> future;
   final Color backgroundColor;
-  final String? backgroundImagePath; // New field for background image
+  final String? backgroundImagePath; 
   final int? selectedTextItemIndex;
   final bool isTrayShown;
   final String? message;
@@ -17,7 +17,7 @@ class CanvasState {
     required this.history,
     required this.future,
     this.backgroundColor = const Color(0xFF1A1A1A),
-    this.backgroundImagePath, // Optional background image path
+    this.backgroundImagePath, 
     this.selectedTextItemIndex,
     this.isTrayShown = false,
     this.message,

--- a/lib/cubit/canvas_state.dart
+++ b/lib/cubit/canvas_state.dart
@@ -6,19 +6,21 @@ class CanvasState {
   final List<CanvasState> history;
   final List<CanvasState> future;
   final Color backgroundColor;
+  final String? backgroundImagePath; // New field for background image
   final int? selectedTextItemIndex;
   final bool isTrayShown;
-  final String? message; // Added message field for save/load feedback
+  final String? message;
   final String? currentPageName;
 
   const CanvasState({
     required this.textItems,
     required this.history,
     required this.future,
-    this.backgroundColor = const Color(0xFF1A1A1A), // Default dark background
+    this.backgroundColor = const Color(0xFF1A1A1A),
+    this.backgroundImagePath, // Optional background image path
     this.selectedTextItemIndex,
     this.isTrayShown = false,
-    this.message, // Optional message field
+    this.message,
     this.currentPageName,
   });
 
@@ -27,7 +29,8 @@ class CanvasState {
       textItems: [],
       history: [],
       future: [],
-      backgroundColor: Color(0xFF1A1A1A), // Default dark background
+      backgroundColor: Color(0xFF1A1A1A),
+      backgroundImagePath: null,
       selectedTextItemIndex: null,
       isTrayShown: false,
       message: null,
@@ -40,6 +43,8 @@ class CanvasState {
     List<CanvasState>? history,
     List<CanvasState>? future,
     Color? backgroundColor,
+    String? backgroundImagePath,
+    bool clearBackgroundImage = false,
     int? selectedTextItemIndex,
     bool deselect = false,
     bool? isTrayShown,
@@ -52,9 +57,12 @@ class CanvasState {
       history: history ?? this.history,
       future: future ?? this.future,
       backgroundColor: backgroundColor ?? this.backgroundColor,
+      backgroundImagePath: clearBackgroundImage 
+          ? null 
+          : (backgroundImagePath ?? this.backgroundImagePath),
       selectedTextItemIndex: deselect ? null : (selectedTextItemIndex ?? this.selectedTextItemIndex),
       isTrayShown: deselect ? false : (isTrayShown ?? this.isTrayShown),
-      message: message, // Allow message to be set to null explicitly
+      message: message,
       currentPageName: clearCurrentPageName ? null : (currentPageName ?? this.currentPageName),
     );
   }
@@ -65,6 +73,7 @@ class CanvasState {
               runtimeType == other.runtimeType &&
               textItems == other.textItems &&
               backgroundColor == other.backgroundColor &&
+              backgroundImagePath == other.backgroundImagePath &&
               selectedTextItemIndex == other.selectedTextItemIndex &&
               history == other.history &&
               future == other.future &&
@@ -75,6 +84,7 @@ class CanvasState {
   int get hashCode =>
       textItems.hashCode ^
       backgroundColor.hashCode ^
+      backgroundImagePath.hashCode ^
       selectedTextItemIndex.hashCode ^
       history.hashCode ^
       future.hashCode ^

--- a/lib/ui/screens/canvas_screen.dart
+++ b/lib/ui/screens/canvas_screen.dart
@@ -9,99 +9,21 @@ import '../../cubit/canvas_state.dart';
 import '../widgets/editable_text_widget.dart';
 import '../widgets/font_controls.dart';
 import '../widgets/background_color_tray.dart';
+import '../widgets/background_options_sheet.dart';
 import '../../utils/custom_snackbar.dart';
 
 class CanvasScreen extends StatelessWidget {
   const CanvasScreen({super.key});
 
-  // NEW: Method to show background options
+  // Method to show background options
   void _showBackgroundOptions(BuildContext context) {
     showModalBottomSheet(
       context: context,
-      backgroundColor: Colors.white,
+      backgroundColor: Colors.transparent,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
-      builder: (context) => Container(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-              'Background Options',
-              style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-                color: Colors.black87,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                Expanded(
-                  child: _BackgroundOptionTile(
-                    icon: Icons.photo_library,
-                    title: 'Upload Image',
-                    subtitle: 'From gallery',
-                    onTap: () {
-                      Navigator.pop(context);
-                      context.read<CanvasCubit>().uploadBackgroundImage();
-                    },
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: _BackgroundOptionTile(
-                    icon: Icons.camera_alt,
-                    title: 'Take Photo',
-                    subtitle: 'Use camera',
-                    onTap: () {
-                      Navigator.pop(context);
-                      context.read<CanvasCubit>().takePhotoForBackground();
-                    },
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                Expanded(
-                  child: _BackgroundOptionTile(
-                    icon: Icons.color_lens,
-                    title: 'Solid Color',
-                    subtitle: 'Pick a color',
-                    onTap: () {
-                      Navigator.pop(context);
-                      context.read<CanvasCubit>().toggleTray();
-                    },
-                  ),
-                ),
-                const SizedBox(width: 12),
-                BlocBuilder<CanvasCubit, CanvasState>(
-                  builder: (context, state) {
-                    return Expanded(
-                      child: _BackgroundOptionTile(
-                        icon: Icons.clear,
-                        title: 'Remove Image',
-                        subtitle: 'Clear background',
-                        enabled: state.backgroundImagePath != null,
-                        onTap: state.backgroundImagePath != null
-                            ? () {
-                                Navigator.pop(context);
-                                context.read<CanvasCubit>().removeBackgroundImage();
-                              }
-                            : null,
-                      ),
-                    );
-                  },
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-          ],
-        ),
-      ),
+      builder: (context) => const BackgroundOptionsSheet(),
     );
   }
 
@@ -152,7 +74,7 @@ class CanvasScreen extends StatelessWidget {
           },
         ),
         actions: <Widget>[
-          // UPDATED: Change background button (now opens background options)
+          // Background options button
           IconButton(
             tooltip: 'Background options',
             icon: const Icon(
@@ -395,65 +317,6 @@ class CanvasScreen extends StatelessWidget {
         ),
       );
     }
-  }
-}
-
-// Custom widget for background option tiles
-class _BackgroundOptionTile extends StatelessWidget {
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final VoidCallback? onTap;
-  final bool enabled;
-
-  const _BackgroundOptionTile({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-    this.onTap,
-    this.enabled = true,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: enabled ? Colors.grey[50] : Colors.grey[200],
-      borderRadius: BorderRadius.circular(12),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: enabled ? onTap : null,
-        child: Container(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            children: [
-              Icon(
-                icon,
-                size: 32,
-                color: enabled ? Colors.black87 : Colors.grey,
-              ),
-              const SizedBox(height: 8),
-              Text(
-                title,
-                style: TextStyle(
-                  fontWeight: FontWeight.w600,
-                  fontSize: 14,
-                  color: enabled ? Colors.black87 : Colors.grey,
-                ),
-                textAlign: TextAlign.center,
-              ),
-              Text(
-                subtitle,
-                style: TextStyle(
-                  fontSize: 12,
-                  color: enabled ? Colors.grey[600] : Colors.grey,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 }
 

--- a/lib/ui/widgets/background_options_sheet.dart
+++ b/lib/ui/widgets/background_options_sheet.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../cubit/canvas_cubit.dart';
+import '../../cubit/canvas_state.dart';
+
+class BackgroundOptionsSheet extends StatelessWidget {
+  const BackgroundOptionsSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Background Options',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              color: Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: _BackgroundOptionTile(
+                  icon: Icons.photo_library,
+                  title: 'Upload Image',
+                  subtitle: 'From gallery',
+                  onTap: () {
+                    Navigator.pop(context);
+                    context.read<CanvasCubit>().uploadBackgroundImage();
+                  },
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _BackgroundOptionTile(
+                  icon: Icons.camera_alt,
+                  title: 'Take Photo',
+                  subtitle: 'Use camera',
+                  onTap: () {
+                    Navigator.pop(context);
+                    context.read<CanvasCubit>().takePhotoForBackground();
+                  },
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _BackgroundOptionTile(
+                  icon: Icons.color_lens,
+                  title: 'Solid Color',
+                  subtitle: 'Pick a color',
+                  onTap: () {
+                    Navigator.pop(context);
+                    context.read<CanvasCubit>().toggleTray();
+                  },
+                ),
+              ),
+              const SizedBox(width: 12),
+              BlocBuilder<CanvasCubit, CanvasState>(
+                builder: (context, state) {
+                  return Expanded(
+                    child: _BackgroundOptionTile(
+                      icon: Icons.clear,
+                      title: 'Remove Image',
+                      subtitle: 'Clear background',
+                      enabled: state.backgroundImagePath != null,
+                      onTap: state.backgroundImagePath != null
+                          ? () {
+                              Navigator.pop(context);
+                              context.read<CanvasCubit>().removeBackgroundImage();
+                            }
+                          : null,
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}
+
+class _BackgroundOptionTile extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback? onTap;
+  final bool enabled;
+
+  const _BackgroundOptionTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    this.onTap,
+    this.enabled = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: enabled ? Colors.grey[50] : Colors.grey[200],
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: enabled ? onTap : null,
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              Icon(
+                icon,
+                size: 32,
+                color: enabled ? Colors.black87 : Colors.grey,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                title,
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
+                  color: enabled ? Colors.black87 : Colors.grey,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              Text(
+                subtitle,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: enabled ? Colors.grey[600] : Colors.grey,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce?
Feature - Add background image upload functionality

### Issue Number:
Fixes #76

### Summary
Adds the ability to upload and set background images in the text editor canvas, enhancing creative possibilities for posters, invitations, and personalized designs. Previously, users were limited to solid background colors only.

### Changes Made:
- Updated `canvas_cubit.dart` and `canvas_state.dart` to handle background image state
- Modified `canvas_screen.dart` to include image upload UI and display logic
- Added necessary Android permissions in `AndroidManifest.xml`

### Have you read the contributing guide, README.md, and code of conduct?
Yes