### PR TITLE
Add label and color preview to Saved Pages

### DIFF
--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -38,7 +38,7 @@ class CanvasCubit extends Cubit<CanvasState> {
   void addText(String text) {
     // Calculate offset based on the number of existing text items
     final offset = state.textItems.length * 20.0; // 20px offset for each item
-    
+
     final newTextItem = TextItem(
       text: text,
       x: 50 + offset,
@@ -99,10 +99,11 @@ class CanvasCubit extends Cubit<CanvasState> {
 
       // Save image to app's document directory
       final savedPath = await _saveImageToAppDirectory(image);
-      
+
       if (savedPath != null) {
         _updateState(backgroundImagePath: savedPath);
-        emit(state.copyWith(message: 'Background image uploaded successfully!'));
+        emit(
+            state.copyWith(message: 'Background image uploaded successfully!'));
       }
     } catch (e) {
       print('Error uploading background image: $e');
@@ -122,10 +123,11 @@ class CanvasCubit extends Cubit<CanvasState> {
 
       // Save image to app's document directory
       final savedPath = await _saveImageToAppDirectory(image);
-      
+
       if (savedPath != null) {
         _updateState(backgroundImagePath: savedPath);
-        emit(state.copyWith(message: 'Background photo captured successfully!'));
+        emit(
+            state.copyWith(message: 'Background photo captured successfully!'));
       }
     } catch (e) {
       print('Error taking photo for background: $e');
@@ -139,7 +141,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     if (state.backgroundImagePath != null) {
       _deleteImageFile(state.backgroundImagePath!);
     }
-    
+
     _updateState(clearBackgroundImage: true);
     emit(state.copyWith(message: 'Background image removed'));
   }
@@ -148,13 +150,14 @@ class CanvasCubit extends Cubit<CanvasState> {
   Future<String?> _saveImageToAppDirectory(XFile image) async {
     try {
       final appDir = await getApplicationDocumentsDirectory();
-      final fileName = 'bg_${DateTime.now().millisecondsSinceEpoch}${path.extension(image.path)}';
+      final fileName =
+          'bg_${DateTime.now().millisecondsSinceEpoch}${path.extension(image.path)}';
       final savedPath = path.join(appDir.path, fileName);
-      
+
       // Copy the file to app directory
       final File imageFile = File(image.path);
       await imageFile.copy(savedPath);
-      
+
       print('Image saved to: $savedPath');
       return savedPath;
     } catch (e) {
@@ -255,7 +258,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     if (state.backgroundImagePath != null) {
       _deleteImageFile(state.backgroundImagePath!);
     }
-    
+
     emit(
       state.copyWith(
         textItems: [],
@@ -296,33 +299,39 @@ class CanvasCubit extends Cubit<CanvasState> {
         deselect: true));
   }
 
-  Future<void> savePage(String pageName) async {
+  Future<void> savePage(String pageName, {String? label, int? color}) async {
     try {
       final prefs = await SharedPreferences.getInstance();
 
       print('🔄 Saving page: $pageName');
 
       final pageData = {
-        'textItems': state.textItems.map((item) => {
-          'text': item.text,
-          'x': item.x,
-          'y': item.y,
-          'fontSize': item.fontSize,
-          'fontWeight': item.fontWeight.index,
-          'fontStyle': item.fontStyle.index,
-          'color': item.color.value,
-          'fontFamily': item.fontFamily,
-          'isUnderlined': item.isUnderlined,
-        }).toList(),
+        'textItems': state.textItems
+            .map((item) => {
+                  'text': item.text,
+                  'x': item.x,
+                  'y': item.y,
+                  'fontSize': item.fontSize,
+                  'fontWeight': item.fontWeight.index,
+                  'fontStyle': item.fontStyle.index,
+                  'color': item.color.value,
+                  'fontFamily': item.fontFamily,
+                  'isUnderlined': item.isUnderlined,
+                })
+            .toList(),
         'backgroundColor': state.backgroundColor.value,
-        'backgroundImagePath': state.backgroundImagePath, // Save background image path
+        'backgroundImagePath':
+            state.backgroundImagePath, // Save background image path
         'timestamp': DateTime.now().millisecondsSinceEpoch,
+        if (label != null && label.isNotEmpty) 'label': label,
+        if (color != null) 'pageColor': color,
       };
 
       print('📦 Page data: ${jsonEncode(pageData)}');
 
       // Save the page data
-      final saved = await prefs.setString('page_$pageName', jsonEncode(pageData));
+      final saved =
+          await prefs.setString('page_$pageName', jsonEncode(pageData));
       print('💾 Page saved successfully: $saved');
 
       // Update saved pages list
@@ -398,7 +407,7 @@ class CanvasCubit extends Cubit<CanvasState> {
 
       // Load background image path if it exists
       final backgroundImagePath = pageData['backgroundImagePath'] as String?;
-      
+
       // Verify the background image file still exists
       String? validImagePath;
       if (backgroundImagePath != null) {
@@ -406,7 +415,7 @@ class CanvasCubit extends Cubit<CanvasState> {
         if (await imageFile.exists()) {
           validImagePath = backgroundImagePath;
         } else {
-          print('⚠️ Background image file not found: $backgroundImagePath');
+          print('⚠ Background image file not found: $backgroundImagePath');
         }
       }
 
@@ -437,7 +446,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     if (state.backgroundImagePath != null) {
       _deleteImageFile(state.backgroundImagePath!);
     }
-    
+
     emit(state.copyWith(
       textItems: [],
       backgroundColor: Colors.black,
@@ -476,7 +485,7 @@ class CanvasCubit extends Cubit<CanvasState> {
   // Delete a saved page (now also cleans up background image files)
   Future<void> deletePage(String pageName) async {
     try {
-      print('🗑️ Deleting page: $pageName');
+      print('🗑 Deleting page: $pageName');
 
       final prefs = await SharedPreferences.getInstance();
 
@@ -485,14 +494,15 @@ class CanvasCubit extends Cubit<CanvasState> {
       if (pageDataString != null) {
         try {
           final pageData = jsonDecode(pageDataString);
-          final backgroundImagePath = pageData['backgroundImagePath'] as String?;
-          
+          final backgroundImagePath =
+              pageData['backgroundImagePath'] as String?;
+
           // Delete the background image file if it exists
           if (backgroundImagePath != null) {
             await _deleteImageFile(backgroundImagePath);
           }
         } catch (e) {
-          print('⚠️ Error reading page data for cleanup: $e');
+          print('⚠ Error reading page data for cleanup: $e');
         }
       }
 
@@ -545,10 +555,14 @@ class CanvasCubit extends Cubit<CanvasState> {
       final preview = {
         'name': pageName,
         'textCount': (pageData['textItems'] as List).length,
-        'backgroundColor': Color(pageData['backgroundColor']),
-        'backgroundImagePath': pageData['backgroundImagePath'], // Include background image
+        'backgroundColor':
+            Color(pageData['pageColor'] ?? pageData['backgroundColor']),
+        'backgroundImagePath':
+            pageData['backgroundImagePath'], // Include background image
         'timestamp': pageData['timestamp'],
-        'lastModified': DateTime.fromMillisecondsSinceEpoch(pageData['timestamp']),
+        'lastModified':
+            DateTime.fromMillisecondsSinceEpoch(pageData['timestamp']),
+        'label': pageData['label'] ?? '',
       };
 
       print('✅ Preview generated for $pageName: ${preview['textCount']} items');
@@ -578,18 +592,20 @@ class CanvasCubit extends Cubit<CanvasState> {
         if (pageDataString != null) {
           try {
             final pageData = jsonDecode(pageDataString);
-            final backgroundImagePath = pageData['backgroundImagePath'] as String?;
+            final backgroundImagePath =
+                pageData['backgroundImagePath'] as String?;
             if (backgroundImagePath != null) {
               await _deleteImageFile(backgroundImagePath);
             }
           } catch (e) {
-            print('⚠️ Error cleaning up image for $key: $e');
+            print('⚠ Error cleaning up image for $key: $e');
           }
         }
       }
 
       // Clear all saved page data
-      final keysToRemove = allKeys.where((key) => key.startsWith('page_') || key == 'saved_pages');
+      final keysToRemove = allKeys
+          .where((key) => key.startsWith('page_') || key == 'saved_pages');
       for (final key in keysToRemove) {
         await prefs.remove(key);
       }

--- a/lib/ui/screens/saved_pages.dart
+++ b/lib/ui/screens/saved_pages.dart
@@ -108,165 +108,180 @@ class _SavedPagesScreenState extends State<SavedPagesScreen> {
       ),
       body: isLoading
           ? const Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CircularProgressIndicator(
-              color: Colors.black54,
-            ),
-            SizedBox(height: 16),
-            Text(
-              'Loading saved pages...',
-              style: TextStyle(
-                color: Colors.black54,
-                fontSize: 16,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  CircularProgressIndicator(
+                    color: Colors.black54,
+                  ),
+                  SizedBox(height: 16),
+                  Text(
+                    'Loading saved pages...',
+                    style: TextStyle(
+                      color: Colors.black54,
+                      fontSize: 16,
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
-      )
+            )
           : savedPages.isEmpty
-          ? Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.description_outlined,
-              size: 80,
-              color: Colors.grey[400],
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'No saved pages yet',
-              style: TextStyle(
-                fontSize: 20,
-                color: Colors.grey[600],
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Create and save your first page!',
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey[500],
-              ),
-            ),
-          ],
-        ),
-      )
-          : RefreshIndicator(
-        onRefresh: _loadSavedPages,
-        child: ListView.builder(
-          padding: const EdgeInsets.all(16),
-          itemCount: pagesPreviews.length,
-          itemBuilder: (context, index) {
-            final preview = pagesPreviews[index];
-            final pageName = preview['name'] as String;
-            final textCount = preview['textCount'] as int;
-            final backgroundColor = preview['backgroundColor'] as Color;
-            final lastModified = preview['lastModified'] as DateTime;
-
-            return Card(
-              margin: const EdgeInsets.only(bottom: 12),
-              elevation: 2,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: InkWell(
-                borderRadius: BorderRadius.circular(12),
-                onTap: () => _loadPage(pageName),
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      // Page preview/thumbnail
-                      Container(
-                        width: 60,
-                        height: 60,
-                        decoration: BoxDecoration(
-                          color: backgroundColor,
-                          borderRadius: BorderRadius.circular(8),
-                          border: Border.all(
-                            color: Colors.grey[300]!,
-                            width: 1,
-                          ),
-                        ),
-                        child: Center(
-                          child: Icon(
-                            Icons.description,
-                            color: Colors.white.withOpacity(0.8),
-                            size: 28,
-                          ),
+                      Icon(
+                        Icons.description_outlined,
+                        size: 80,
+                        color: Colors.grey[400],
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'No saved pages yet',
+                        style: TextStyle(
+                          fontSize: 20,
+                          color: Colors.grey[600],
+                          fontWeight: FontWeight.w500,
                         ),
                       ),
-                      const SizedBox(width: 16),
-                      // Page info
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              pageName,
-                              style: const TextStyle(
-                                fontSize: 18,
-                                fontWeight: FontWeight.w600,
-                                color: Colors.black87,
-                              ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              '$textCount text item${textCount != 1 ? 's' : ''}',
-                              style: TextStyle(
-                                fontSize: 14,
-                                color: Colors.grey[600],
-                              ),
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              'Modified ${_formatDateTime(lastModified)}',
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: Colors.grey[500],
-                              ),
-                            ),
-                          ],
+                      const SizedBox(height: 8),
+                      Text(
+                        'Create and save your first page!',
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: Colors.grey[500],
                         ),
-                      ),
-                      // Action buttons
-                      Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          IconButton(
-                            icon: const Icon(
-                              Icons.open_in_new,
-                              color: Colors.blue,
-                              size: 20,
-                            ),
-                            onPressed: () => _loadPage(pageName),
-                            tooltip: 'Open',
-                          ),
-                          IconButton(
-                            icon: const Icon(
-                              Icons.delete_outline,
-                              color: Colors.red,
-                              size: 20,
-                            ),
-                            onPressed: () => _showDeleteConfirmation(pageName),
-                            tooltip: 'Delete',
-                          ),
-                        ],
                       ),
                     ],
                   ),
+                )
+              : RefreshIndicator(
+                  onRefresh: _loadSavedPages,
+                  child: ListView.builder(
+                    padding: const EdgeInsets.all(16),
+                    itemCount: pagesPreviews.length,
+                    itemBuilder: (context, index) {
+                      final preview = pagesPreviews[index];
+                      final pageName = preview['name'] as String;
+                      final textCount = preview['textCount'] as int? ?? 0;
+                      final backgroundColor =
+                          preview['backgroundColor'] as Color? ?? Colors.grey;
+                      final lastModified = preview['lastModified'] as DateTime;
+                      final label = (preview['label'] as String?) ?? '';
+
+                      return Card(
+                        margin: const EdgeInsets.only(bottom: 12),
+                        elevation: 2,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: InkWell(
+                          borderRadius: BorderRadius.circular(12),
+                          onTap: () => _loadPage(pageName),
+                          child: Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: Row(
+                              children: [
+                                // Page preview/thumbnail
+                                Container(
+                                  width: 60,
+                                  height: 60,
+                                  decoration: BoxDecoration(
+                                    color: backgroundColor,
+                                    borderRadius: BorderRadius.circular(8),
+                                    border: Border.all(
+                                      color: Colors.grey[300]!,
+                                      width: 1,
+                                    ),
+                                  ),
+                                  child: Center(
+                                    child: label.isNotEmpty
+                                        ? Text(
+                                            label,
+                                            style: const TextStyle(
+                                              color: Colors.white,
+                                              fontWeight: FontWeight.bold,
+                                              fontSize: 14,
+                                            ),
+                                            textAlign: TextAlign.center,
+                                          )
+                                        : Icon(
+                                            Icons.description,
+                                            color:
+                                                Colors.white.withOpacity(0.8),
+                                            size: 28,
+                                          ),
+                                  ),
+                                ),
+                                const SizedBox(width: 16),
+                                // Page info
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        pageName,
+                                        style: const TextStyle(
+                                          fontSize: 18,
+                                          fontWeight: FontWeight.w600,
+                                          color: Colors.black87,
+                                        ),
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        '$textCount text item${textCount != 1 ? 's' : ''}',
+                                        style: TextStyle(
+                                          fontSize: 14,
+                                          color: Colors.grey[600],
+                                        ),
+                                      ),
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        'Modified ${_formatDateTime(lastModified)}',
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          color: Colors.grey[500],
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                // Action buttons
+                                Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    IconButton(
+                                      icon: const Icon(
+                                        Icons.open_in_new,
+                                        color: Colors.blue,
+                                        size: 20,
+                                      ),
+                                      onPressed: () => _loadPage(pageName),
+                                      tooltip: 'Open',
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(
+                                        Icons.delete_outline,
+                                        color: Colors.red,
+                                        size: 20,
+                                      ),
+                                      onPressed: () =>
+                                          _showDeleteConfirmation(pageName),
+                                      tooltip: 'Delete',
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
                 ),
-              ),
-            );
-          },
-        ),
-      ),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   google_fonts: ^6.3.0
   super_clipboard: ^0.9.1
   shared_preferences: ^2.5.3
+  image_picker: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Issue:
Fixes #88

Title:
Add label and color preview to Saved Pages

Description:
Problem: Saved pages are hard to visually scan when many exist.

Solution:
Add an optional label and a compact color picker to the Save dialog.
Persist label + pageColor and show a colored preview (grey default) with the label in Saved Pages.

Files updated:
save_page_dialog.dart (label + color UI)
canvas_cubit.dart (persist label and pageColor)
saved_pages.dart (render preview color/label)