### PR TITLE
feat: add text alignment options (left, right, center, justify)

### DIFF
--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -252,6 +252,16 @@ class CanvasCubit extends Cubit<CanvasState> {
     _updateState(textItems: updatedItems);
   }
 
+  // method to change text alignment
+  void changeTextAlignment(int index, TextAlign align) {
+    if (index < 0 || index >= state.textItems.length) return;
+
+    final updatedItems = List<TextItem>.from(state.textItems);
+    updatedItems[index] = updatedItems[index].copyWith(textAlign: align);
+
+    emit(state.copyWith(textItems: updatedItems));
+  }
+
   // method to undo changes and emit it
   void undo() {
     if (state.history.isNotEmpty) {
@@ -341,6 +351,7 @@ class CanvasCubit extends Cubit<CanvasState> {
                   'color': item.color.value,
                   'fontFamily': item.fontFamily,
                   'isUnderlined': item.isUnderlined,
+                  'textAlign': item.textAlign.index, // Save alignment as integer
                 })
             .toList(),
         'backgroundColor': state.backgroundColor.value,
@@ -426,6 +437,7 @@ class CanvasCubit extends Cubit<CanvasState> {
           color: Color(item['color']),
           fontFamily: item['fontFamily'],
           isUnderlined: item['isUnderlined'] ?? false,
+           textAlign: TextAlign.values[item['textAlign'] ?? 0], // Default to left if missing
         );
       }).toList();
 

--- a/lib/cubit/canvas_state.dart
+++ b/lib/cubit/canvas_state.dart
@@ -62,7 +62,7 @@ class CanvasState {
           : (backgroundImagePath ?? this.backgroundImagePath),
       selectedTextItemIndex: deselect ? null : (selectedTextItemIndex ?? this.selectedTextItemIndex),
       isTrayShown: deselect ? false : (isTrayShown ?? this.isTrayShown),
-      message: message,
+       message: message ?? this.message,
       currentPageName: clearCurrentPageName ? null : (currentPageName ?? this.currentPageName),
     );
   }

--- a/lib/models/text_item_model.dart
+++ b/lib/models/text_item_model.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+import 'package:flutter/material.dart';
 
 class TextItem {
   final String text;
@@ -12,6 +13,7 @@ class TextItem {
   final Color color;
   final bool isHighlighted;
   final Color? highlightColor;
+  final TextAlign textAlign; 
 
   TextItem({
     required this.text,
@@ -25,6 +27,7 @@ class TextItem {
     required this.color,
     this.isHighlighted = false,
     this.highlightColor,
+    this.textAlign = TextAlign.left, 
   });
 
   TextItem copyWith({
@@ -39,6 +42,7 @@ class TextItem {
     Color? color,
     bool? isHighlighted,
     Color? highlightColor,
+     TextAlign? textAlign, 
   }) {
     return TextItem(
       text: text ?? this.text,
@@ -52,6 +56,7 @@ class TextItem {
       color: color ?? this.color,
       isHighlighted: isHighlighted ?? this.isHighlighted,
       highlightColor: highlightColor ?? this.highlightColor,
+       textAlign: textAlign ?? this.textAlign, 
     );
   }
 

--- a/lib/ui/widgets/editable_text_widget.dart
+++ b/lib/ui/widgets/editable_text_widget.dart
@@ -39,8 +39,11 @@ class EditableTextWidget extends StatelessWidget {
         }
       },
       // 4. onDoubleTap handler is now gone
-      child: Text(
+      child:SizedBox(
+        width: MediaQuery.of(context).size.width * 0.9,
+        child: Text(
         textItem.text,
+        textAlign: textItem.textAlign,
         style: GoogleFonts.getFont(
           textItem.fontFamily,
           fontStyle: textItem.fontStyle,
@@ -57,7 +60,7 @@ class EditableTextWidget extends StatelessWidget {
                       ? Colors.yellow.withAlpha((0.3 * 255).toInt())
                       : null),
         ),
-      ),
+      ),)
     );
   }
 }

--- a/lib/ui/widgets/font_controls.dart
+++ b/lib/ui/widgets/font_controls.dart
@@ -33,6 +33,8 @@ class FontControls extends StatelessWidget {
             const SizedBox(width: 25),
             _buildFontStyleControls(context),
             const SizedBox(width: 25),
+            _buildAlignmentControls(context),
+            const SizedBox(width: 25),
             _buildHighlightControls(context), 
             const SizedBox(width: 25),
             _buildFontFamilyControls(context),
@@ -327,6 +329,98 @@ class FontControls extends StatelessWidget {
       },
     );
   }
+  
+Widget _buildAlignmentControls(BuildContext context) {
+  return BlocBuilder<CanvasCubit, CanvasState>(
+    buildWhen: (previous, current) {
+      // Only rebuild if selection changed or textAlign changed
+      final prevIndex = previous.selectedTextItemIndex;
+      final currIndex = current.selectedTextItemIndex;
+
+      if (prevIndex != currIndex) return true;
+
+      if (currIndex != null &&
+          currIndex < previous.textItems.length &&
+          currIndex < current.textItems.length) {
+        final prevItem = previous.textItems[currIndex];
+        final currItem = current.textItems[currIndex];
+        return prevItem.textAlign != currItem.textAlign;
+      }
+
+      return false;
+    },
+    builder: (context, state) {
+      final selectedIndex = state.selectedTextItemIndex;
+      final isDisabled =
+          selectedIndex == null || selectedIndex >= state.textItems.length;
+
+      final textItem = !isDisabled ? state.textItems[selectedIndex] : null;
+      final currentAlign = textItem?.textAlign ?? TextAlign.left;
+
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Align',
+            style: TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+          ),
+          const SizedBox(width: 12),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            decoration: BoxDecoration(
+              color: Colors.grey[100],
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Colors.grey[300]!),
+            ),
+            child: Row(
+              children: [
+                _buildStyleButton(
+                  icon: Icons.format_align_left,
+                  isSelected: currentAlign == TextAlign.left,
+                  onPressed: isDisabled
+                      ? null
+                      : () => context
+                          .read<CanvasCubit>()
+                          .changeTextAlignment(selectedIndex, TextAlign.left),
+                ),
+                const SizedBox(width: 8),
+                _buildStyleButton(
+                  icon: Icons.format_align_center,
+                  isSelected: currentAlign == TextAlign.center,
+                  onPressed: isDisabled
+                      ? null
+                      : () => context
+                          .read<CanvasCubit>()
+                          .changeTextAlignment(selectedIndex, TextAlign.center),
+                ),
+                const SizedBox(width: 8),
+                _buildStyleButton(
+                  icon: Icons.format_align_right,
+                  isSelected: currentAlign == TextAlign.right,
+                  onPressed: isDisabled
+                      ? null
+                      : () => context
+                          .read<CanvasCubit>()
+                          .changeTextAlignment(selectedIndex, TextAlign.right),
+                ),
+                const SizedBox(width: 8),
+                _buildStyleButton(
+                  icon: Icons.format_align_justify,
+                  isSelected: currentAlign == TextAlign.justify,
+                  onPressed: isDisabled
+                      ? null
+                      : () => context
+                          .read<CanvasCubit>()
+                          .changeTextAlignment(selectedIndex, TextAlign.justify),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+    },
+  );
+}
 
   Widget _buildFontFamilyControls(BuildContext context) {
     return BlocBuilder<CanvasCubit, CanvasState>(


### PR DESCRIPTION
### What kind of change does this PR introduce?

Feature – Added text alignment support for text items.

### Issue Number:

Fixes #84 

### Snapshots/Videos:

<img width="2157" height="1215" alt="image" src="https://github.com/user-attachments/assets/21884e73-67a8-4054-aed6-ab5373bdc5ca" />
<img width="2159" height="1217" alt="image" src="https://github.com/user-attachments/assets/a3c09c79-a122-4e34-bfaa-a0255460f88d" />
<img width="2157" height="1228" alt="image" src="https://github.com/user-attachments/assets/be3a10c1-71a2-4383-b043-887db666da97" />
<img width="2159" height="1228" alt="image" src="https://github.com/user-attachments/assets/dfaf682b-69f1-4c7a-99d9-5b5407a434b8" />


### Summary

This PR introduces the ability to align text (left, center, right, justify) inside the editor.
Users can now adjust text alignment via the font controls panel, and the changes are reflected on the canvas.

### Does this PR introduce a breaking change?

No.
Existing text items default to left alignment, so backward compatibility is preserved.

### Other information

- Added textAlign property to TextItem model.
- Updated EditableTextWidget to respect textAlign.
- Implemented changeTextAlignment method in CanvasCubit.
- Added UI controls for alignment in font_controls.dart.

### Have you read the [contributing guide](https://github.com/may-tas/TextEditingApp/blob/main/CONTRIBUTING.md) , [README.md](https://github.com/may-tas/TextEditingApp/blob/main/README.md) , [code of conduct](https://github.com/may-tas/TextEditingApp/blob/main/CODE_OF_CONDUCT.md)?

Yes ✅
