### PR TITLE
fix: conflicting snackbars

### DIFF
--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -307,7 +307,6 @@ class CanvasCubit extends Cubit<CanvasState> {
         history: newHistory,
         future: [state, ...state.future],
       ));
-      CustomSnackbar.showInfo('Action undone');
     }
   }
 
@@ -320,7 +319,6 @@ class CanvasCubit extends Cubit<CanvasState> {
         future: newFuture,
         history: [...state.history, state],
       ));
-      CustomSnackbar.showInfo('Action redone');
     }
   }
 

--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -307,6 +307,7 @@ class CanvasCubit extends Cubit<CanvasState> {
         history: newHistory,
         future: [state, ...state.future],
       ));
+      CustomSnackbar.showInfo('Action undone');
     }
   }
 
@@ -319,6 +320,7 @@ class CanvasCubit extends Cubit<CanvasState> {
         future: newFuture,
         history: [...state.history, state],
       ));
+      CustomSnackbar.showInfo('Action redone');
     }
   }
 
@@ -342,6 +344,7 @@ class CanvasCubit extends Cubit<CanvasState> {
         clearBackgroundImage: true,
       ),
     );
+    CustomSnackbar.showInfo('Canvas cleared');
   }
 
   void _updateState({
@@ -884,6 +887,7 @@ class CanvasCubit extends Cubit<CanvasState> {
       history: newHistory,
       future: [], // Clear future as we've made a new action
     ));
+    CustomSnackbar.showInfo('Drawings cleared');
   }
 
   // Undo the last drawing stroke

--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -150,12 +150,11 @@ class CanvasCubit extends Cubit<CanvasState> {
 
       if (savedPath != null) {
         _updateState(backgroundImagePath: savedPath);
-        emit(
-            state.copyWith(message: 'Background image uploaded successfully!'));
+        CustomSnackbar.showSuccess('Background image uploaded successfully!');
       }
     } catch (e) {
       log('Error uploading background image: $e');
-      emit(state.copyWith(message: 'Error uploading image: $e'));
+      CustomSnackbar.showError('Error uploading image: $e');
     }
   }
 
@@ -174,12 +173,11 @@ class CanvasCubit extends Cubit<CanvasState> {
 
       if (savedPath != null) {
         _updateState(backgroundImagePath: savedPath);
-        emit(
-            state.copyWith(message: 'Background photo captured successfully!'));
+        CustomSnackbar.showSuccess('Background photo captured successfully!');
       }
     } catch (e) {
       log('Error taking photo for background: $e');
-      emit(state.copyWith(message: 'Error taking photo: $e'));
+      CustomSnackbar.showError('Error taking photo: $e');
     }
   }
 
@@ -191,7 +189,7 @@ class CanvasCubit extends Cubit<CanvasState> {
     }
 
     _updateState(clearBackgroundImage: true);
-    emit(state.copyWith(message: 'Background image removed'));
+    CustomSnackbar.showInfo('Background image removed');
   }
 
   // Helper method to save image to app directory
@@ -430,14 +428,12 @@ class CanvasCubit extends Cubit<CanvasState> {
       // Set the current page name and emit success message
       emit(state.copyWith(
         currentPageName: pageName,
-        message: 'Page "$pageName" saved successfully!',
       ));
+      CustomSnackbar.showSuccess('Page "$pageName" saved successfully!');
     } catch (e, stackTrace) {
       log('❌ Error saving page: $e');
       log('Stack trace: $stackTrace');
-      emit(state.copyWith(
-        message: 'Error saving page: $e',
-      ));
+      CustomSnackbar.showError('Error saving page: $e');
     }
   }
 
@@ -463,7 +459,7 @@ class CanvasCubit extends Cubit<CanvasState> {
 
       if (pageDataString == null) {
         log('❌ Page not found: $pageName');
-        emit(state.copyWith(message: 'Page "$pageName" not found'));
+        CustomSnackbar.showError('Page "$pageName" not found');
         return;
       }
 
@@ -523,17 +519,15 @@ class CanvasCubit extends Cubit<CanvasState> {
         backgroundColor: Color(pageData['backgroundColor']),
         backgroundImagePath: validImagePath,
         selectedTextItemIndex: null,
-        message: 'Page "$pageName" loaded successfully!',
         history: [],
         future: [],
         currentPageName: pageName,
       ));
+      CustomSnackbar.showSuccess('Page "$pageName" loaded successfully!');
     } catch (e, stackTrace) {
       log('❌ Error loading page: $e');
       log('Stack trace: $stackTrace');
-      emit(state.copyWith(
-        message: 'Error loading page: $e',
-      ));
+      CustomSnackbar.showError('Error loading page: $e');
     }
   }
 
@@ -554,8 +548,8 @@ class CanvasCubit extends Cubit<CanvasState> {
       isDrawingMode: false, // Exit drawing mode when creating new page
       clearCurrentPageName: true,
       clearBackgroundImage: true,
-      message: 'New page created',
     ));
+    CustomSnackbar.showInfo('New page created');
   }
 
   // Get list of saved pages
@@ -621,19 +615,13 @@ class CanvasCubit extends Cubit<CanvasState> {
       if (state.currentPageName == pageName) {
         emit(state.copyWith(
           clearCurrentPageName: true,
-          message: 'Page "$pageName" deleted successfully!',
-        ));
-      } else {
-        emit(state.copyWith(
-          message: 'Page "$pageName" deleted successfully!',
         ));
       }
+      CustomSnackbar.showSuccess('Page "$pageName" deleted successfully!');
     } catch (e, stackTrace) {
       log('❌ Error deleting page: $e');
       log('Stack trace: $stackTrace');
-      emit(state.copyWith(
-        message: 'Error deleting page: $e',
-      ));
+      CustomSnackbar.showError('Error deleting page: $e');
     }
   }
 
@@ -671,11 +659,6 @@ class CanvasCubit extends Cubit<CanvasState> {
       log('Stack trace: $stackTrace');
       return null;
     }
-  }
-
-  // Clear message (useful for dismissing notifications)
-  void clearMessage() {
-    emit(state.copyWith(message: null));
   }
 
   // Debug method to clear all saved data (now also cleans up image files)
@@ -717,12 +700,13 @@ class CanvasCubit extends Cubit<CanvasState> {
       log('🧹 Cleared all saved data: $keysToRemove');
 
       emit(state.copyWith(
-        message: 'All saved data cleared!',
         clearCurrentPageName: true,
         clearBackgroundImage: true,
       ));
+      CustomSnackbar.showSuccess('All saved data cleared!');
     } catch (e) {
       log('❌ Error clearing saved data: $e');
+      CustomSnackbar.showError('Error clearing saved data: $e');
     }
   }
 

--- a/lib/cubit/canvas_state.dart
+++ b/lib/cubit/canvas_state.dart
@@ -12,7 +12,6 @@ class CanvasState {
   final String? backgroundImagePath;
   final int? selectedTextItemIndex;
   final bool isTrayShown;
-  final String? message;
   final String? currentPageName;
   final bool isDrawingMode;
   final Color currentDrawColor;
@@ -28,7 +27,6 @@ class CanvasState {
     this.backgroundImagePath,
     this.selectedTextItemIndex,
     this.isTrayShown = false,
-    this.message,
     this.currentPageName,
     this.isDrawingMode = false,
     this.currentDrawColor = ColorConstants.dialogTextBlack,
@@ -46,7 +44,6 @@ class CanvasState {
       backgroundImagePath: null,
       selectedTextItemIndex: null,
       isTrayShown: false,
-      message: null,
       currentPageName: null,
       isDrawingMode: false,
       currentDrawColor: ColorConstants.dialogTextBlack,
@@ -70,7 +67,6 @@ class CanvasState {
     Color? currentDrawColor,
     double? currentStrokeWidth,
     BrushType? currentBrushType,
-    String? message,
     String? currentPageName,
     bool clearCurrentPageName = false,
   }) {
@@ -87,7 +83,6 @@ class CanvasState {
           ? null
           : (selectedTextItemIndex ?? this.selectedTextItemIndex),
       isTrayShown: deselect ? false : (isTrayShown ?? this.isTrayShown),
-      message: message ?? this.message,
       currentPageName: clearCurrentPageName
           ? null
           : (currentPageName ?? this.currentPageName),
@@ -112,7 +107,6 @@ class CanvasState {
           history == other.history &&
           future == other.future &&
           isTrayShown == other.isTrayShown &&
-          message == other.message &&
           currentPageName == other.currentPageName &&
           currentDrawColor == other.currentDrawColor &&
           currentStrokeWidth == other.currentStrokeWidth &&
@@ -132,6 +126,5 @@ class CanvasState {
       currentDrawColor.hashCode ^
       currentStrokeWidth.hashCode ^
       currentBrushType.hashCode ^
-      message.hashCode ^
       currentPageName.hashCode;
 }

--- a/lib/ui/screens/canvas_screen.dart
+++ b/lib/ui/screens/canvas_screen.dart
@@ -72,11 +72,10 @@ class CanvasScreen extends StatelessWidget {
             if (cubit.state.textItems.isNotEmpty ||
                 cubit.state.backgroundImagePath != null) {
               cubit.clearCanvas();
-              CustomSnackbar.showInfo('Canvas cleared');
             } else if (cubit.state.drawPaths.isNotEmpty) {
               cubit.clearDrawings();
-              CustomSnackbar.showInfo('Drawings cleared');
             } else {
+              // Show info when canvas is already empty
               CustomSnackbar.showInfo('Canvas is already empty');
             }
           },
@@ -99,7 +98,6 @@ class CanvasScreen extends StatelessWidget {
               final cubit = context.read<CanvasCubit>();
               if (cubit.state.history.isNotEmpty) {
                 cubit.undo();
-                CustomSnackbar.showInfo('Action undone');
               } else {
                 CustomSnackbar.showInfo('Nothing to undo');
               }
@@ -113,7 +111,6 @@ class CanvasScreen extends StatelessWidget {
               final cubit = context.read<CanvasCubit>();
               if (cubit.state.future.isNotEmpty) {
                 cubit.redo();
-                CustomSnackbar.showInfo('Action redone');
               } else {
                 CustomSnackbar.showInfo('Nothing to redo');
               }
@@ -133,7 +130,6 @@ class CanvasScreen extends StatelessWidget {
                   switch (value) {
                     case 'new_page':
                       cubit.createNewPage();
-                      CustomSnackbar.showInfo('New page created');
                       break;
                     case 'load_pages':
                       Navigator.push(

--- a/lib/ui/screens/canvas_screen.dart
+++ b/lib/ui/screens/canvas_screen.dart
@@ -220,15 +220,7 @@ class CanvasScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: BlocConsumer<CanvasCubit, CanvasState>(
-        listener: (context, state) {
-          // Show snackbar when there's a message from save/load operations
-          if (state.message != null) {
-            CustomSnackbar.showInfo(state.message!);
-            // Clear the message after showing
-            context.read<CanvasCubit>().clearMessage();
-          }
-        },
+      body: BlocBuilder<CanvasCubit, CanvasState>(
         builder: (context, state) {
           return GestureDetector(
             onTap: () {

--- a/lib/ui/screens/save_page_dialog.dart
+++ b/lib/ui/screens/save_page_dialog.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:texterra/utils/custom_snackbar.dart';
 
 import '../../cubit/canvas_cubit.dart';
 import '../../constants/color_constants.dart';
@@ -99,17 +98,12 @@ class _SavePageDialogState extends State<SavePageDialog> {
 
       if (mounted) {
         Navigator.of(context).pop();
-
-        // Show success message
-        CustomSnackbar.showSuccess('Page "$pageName" saved successfully!');
       }
     } catch (e) {
       if (mounted) {
         setState(() {
           _isSaving = false;
         });
-
-        CustomSnackbar.showError('Error saving page: $e');
       }
     }
   }

--- a/lib/ui/screens/saved_pages.dart
+++ b/lib/ui/screens/saved_pages.dart
@@ -51,7 +51,7 @@ class _SavedPagesScreenState extends State<SavedPagesScreen> {
     } catch (e) {
       // Handle error
       if (mounted) {
-        CustomSnackbar.showError('Error deleting page');
+        CustomSnackbar.showError('Error loading pages');
       }
     } finally {
       if (mounted) {
@@ -295,9 +295,7 @@ class _SavedPagesScreenState extends State<SavedPagesScreen> {
         Navigator.of(context).pop();
       }
     } catch (e) {
-      if (mounted) {
-        CustomSnackbar.showError('Error deleting page');
-      }
+      // Error is already handled by cubit
     }
   }
 
@@ -358,14 +356,8 @@ class _SavedPagesScreenState extends State<SavedPagesScreen> {
     try {
       await context.read<CanvasCubit>().deletePage(pageName);
       await _loadSavedPages(); // Refresh the list
-
-      if (mounted) {
-        CustomSnackbar.showSuccess('Page "$pageName" deleted successfully');
-      }
     } catch (e) {
-      if (mounted) {
-        CustomSnackbar.showError('Error deleting page');
-      }
+      // Error is already handled by cubit
     }
   }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bug fix - Fixes snackbar message conflicts and improves UI feedback system

### Issue Number:

Fixes #104 

### Snapshots/Videos:

uploaded in the #104 

### Summary

This PR addresses critical issues with the snackbar implementation in the canvas screen:

Problems Solved:
Message Overshadowing: The BlocConsumer listener was automatically showing snackbars for any state.message using only CustomSnackbar.showInfo(), which could overshadow other snackbars triggered by user actions (like undo, redo, clear canvas operations)

Limited Snackbar Types: The automatic message system only used showInfo(), preventing the use of showSuccess() or showError() snackbars for appropriate contextual feedback

Inefficient State Management: The system required a message parameter in the state that needed to be manually cleared after each use, leading to unnecessary state updates and potential race conditions

Changes Made:
✅ Removed message field from CanvasState and related state management methods
✅ Replaced automatic snackbar display in BlocConsumer listener with direct calls to appropriate CustomSnackbar methods
✅ Implemented proper success (green), error (red), and info (blue) snackbar types with contextual feedback
✅ Eliminated the need for clearMessage() method and related state updates
✅ Improved separation of concerns between business logic and UI feedback

### Does this PR introduce a breaking change?

no

### Other information

Testing performed:
✅ Verified success snackbars display correctly for save operations
✅ Verified info snackbars display correctly for informational messages
✅ Confirmed no snackbar message conflicts occur during rapid operations
✅ Ensured all existing functionality works as expected

### Have you read the [contributing guide](https://github.com/may-tas/TextEditingApp/blob/main/CONTRIBUTING.md) , [README.md](https://github.com/may-tas/TextEditingApp/blob/main/README.md) , [code of conduct](https://github.com/may-tas/TextEditingApp/blob/main/CODE_OF_CONDUCT.md)?

yes
