### PR TITLE
Feature/brush and marker

### DIFF
--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -803,6 +803,34 @@ class CanvasCubit extends Cubit<CanvasState> {
           ..strokeWidth = strokeWidth * 0.8
           ..filterQuality = FilterQuality.low;
         break;
+      case BrushType.watercolor:
+        paint
+          ..color = color.withValues(alpha: 0.6)
+          ..strokeWidth = strokeWidth * 1.2
+          ..filterQuality = FilterQuality.high
+          ..blendMode = BlendMode.colorBurn;
+        break;
+      case BrushType.oilPaint:
+        paint
+          ..color = color
+          ..strokeWidth = strokeWidth * 1.8
+          ..filterQuality = FilterQuality.high
+          ..strokeCap = StrokeCap.square;
+        break;
+      case BrushType.charcoal:
+        paint
+          ..color = color.withValues(alpha: 0.8)
+          ..strokeWidth = strokeWidth * 2.5
+          ..filterQuality = FilterQuality.low
+          ..blendMode = BlendMode.multiply;
+        break;
+      case BrushType.sprayPaint:
+        paint
+          ..color = color.withValues(alpha: 0.4)
+          ..strokeWidth = strokeWidth * 3.0
+          ..filterQuality = FilterQuality.medium
+          ..blendMode = BlendMode.screen;
+        break;
     }
     return paint;
   }

--- a/lib/cubit/canvas_cubit.dart
+++ b/lib/cubit/canvas_cubit.dart
@@ -791,46 +791,6 @@ class CanvasCubit extends Cubit<CanvasState> {
           ..strokeWidth = strokeWidth * 1.5
           ..filterQuality = FilterQuality.medium;
         break;
-      case BrushType.highlighter:
-        paint
-          ..color = color.withValues(alpha: 0.3)
-          ..strokeWidth = strokeWidth * 2.0
-          ..blendMode = BlendMode.multiply;
-        break;
-      case BrushType.pencil:
-        paint
-          ..color = color
-          ..strokeWidth = strokeWidth * 0.8
-          ..filterQuality = FilterQuality.low;
-        break;
-      case BrushType.watercolor:
-        paint
-          ..color = color.withValues(alpha: 0.6)
-          ..strokeWidth = strokeWidth * 1.2
-          ..filterQuality = FilterQuality.high
-          ..blendMode = BlendMode.colorBurn;
-        break;
-      case BrushType.oilPaint:
-        paint
-          ..color = color
-          ..strokeWidth = strokeWidth * 1.8
-          ..filterQuality = FilterQuality.high
-          ..strokeCap = StrokeCap.square;
-        break;
-      case BrushType.charcoal:
-        paint
-          ..color = color.withValues(alpha: 0.8)
-          ..strokeWidth = strokeWidth * 2.5
-          ..filterQuality = FilterQuality.low
-          ..blendMode = BlendMode.multiply;
-        break;
-      case BrushType.sprayPaint:
-        paint
-          ..color = color.withValues(alpha: 0.4)
-          ..strokeWidth = strokeWidth * 3.0
-          ..filterQuality = FilterQuality.medium
-          ..blendMode = BlendMode.screen;
-        break;
     }
     return paint;
   }

--- a/lib/models/draw_model.dart
+++ b/lib/models/draw_model.dart
@@ -1,14 +1,8 @@
 import 'package:flutter/material.dart';
 
-enum BrushType { 
-  brush, 
-  marker, 
-  highlighter, 
-  pencil,
-  watercolor,
-  oilPaint,
-  charcoal,
-  sprayPaint,
+enum BrushType {
+  brush,
+  marker,
 }
 
 class DrawingPoint {

--- a/lib/models/draw_model.dart
+++ b/lib/models/draw_model.dart
@@ -1,6 +1,15 @@
 import 'package:flutter/material.dart';
 
-enum BrushType { brush, marker, highlighter, pencil }
+enum BrushType { 
+  brush, 
+  marker, 
+  highlighter, 
+  pencil,
+  watercolor,
+  oilPaint,
+  charcoal,
+  sprayPaint,
+}
 
 class DrawingPoint {
   final Offset offset;

--- a/lib/ui/screens/canvas_screen.dart
+++ b/lib/ui/screens/canvas_screen.dart
@@ -236,6 +236,7 @@ class CanvasScreen extends StatelessWidget {
                     isDrawingMode: state.isDrawingMode,
                     currentDrawColor: state.currentDrawColor,
                     currentStrokeWidth: state.currentStrokeWidth,
+                    currentBrushType: state.currentBrushType,
                     onStartDrawing: (offset) {
                       context.read<CanvasCubit>().startNewDrawPath(offset);
                     },
@@ -250,6 +251,9 @@ class CanvasScreen extends StatelessWidget {
                     },
                     onStrokeWidthChanged: (width) {
                       context.read<CanvasCubit>().setStrokeWidth(width);
+                    },
+                    onBrushTypeChanged: (brushType) {
+                      context.read<CanvasCubit>().setBrushType(brushType);
                     },
                     onUndoDrawing: () {
                       context.read<CanvasCubit>().undoLastDrawing();

--- a/lib/ui/widgets/drawing/drawing_painter.dart
+++ b/lib/ui/widgets/drawing/drawing_painter.dart
@@ -32,6 +32,8 @@ class DrawingPainter extends CustomPainter {
     if (points.isEmpty) return;
 
     // All brush types use standard stroke rendering
+    // TODO: Use this method to Add new brush type render methods here (e.g., spray, charcoal, watercolor) instead of modifying paint().
+    
     _renderStandardStroke(canvas, path);
   }
 

--- a/lib/ui/widgets/drawing/drawing_painter.dart
+++ b/lib/ui/widgets/drawing/drawing_painter.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../models/draw_model.dart';
+import 'dart:math' as math;
 
 class DrawingPainter extends CustomPainter {
   final List<DrawPath> paths;
@@ -18,16 +19,101 @@ class DrawingPainter extends CustomPainter {
         canvas.drawRect(Offset.zero & size, paint);
         continue; // Skip the regular path drawing for fill operations
       }
+
       final points = path.points;
       if (points.isEmpty) continue;
 
-      final paint = points.first.paint;
+      // Use brush-specific rendering
+      _renderBrushStroke(canvas, path);
+    }
+  }
 
-      if (points.length == 1) {
-        // Draw a dot for single point
-        canvas.drawCircle(points.first.offset, paint.strokeWidth / 2, paint);
-      } else {
-        // Draw a path for multiple points
+  void _renderBrushStroke(Canvas canvas, DrawPath path) {
+    final points = path.points;
+    if (points.isEmpty) return;
+
+    switch (path.brushType) {
+      case BrushType.sprayPaint:
+        _renderSprayPaint(canvas, path);
+        break;
+      case BrushType.charcoal:
+        _renderCharcoal(canvas, path);
+        break;
+      case BrushType.watercolor:
+        _renderWatercolor(canvas, path);
+        break;
+      case BrushType.oilPaint:
+        _renderOilPaint(canvas, path);
+        break;
+      default:
+        _renderStandardStroke(canvas, path);
+        break;
+    }
+  }
+
+  void _renderStandardStroke(Canvas canvas, DrawPath path) {
+    final points = path.points;
+    final paint = points.first.paint;
+
+    if (points.length == 1) {
+      // Draw a dot for single point
+      canvas.drawCircle(points.first.offset, paint.strokeWidth / 2, paint);
+    } else {
+      // Draw a path for multiple points
+      final drawPath = Path();
+      drawPath.moveTo(points.first.offset.dx, points.first.offset.dy);
+
+      for (int i = 1; i < points.length; i++) {
+        drawPath.lineTo(points[i].offset.dx, points[i].offset.dy);
+      }
+
+      canvas.drawPath(drawPath, paint);
+    }
+  }
+
+  void _renderSprayPaint(Canvas canvas, DrawPath path) {
+    final points = path.points;
+    final basePaint = points.first.paint;
+
+    // Create spray effect with multiple small dots
+    for (var point in points) {
+      final sprayRadius = basePaint.strokeWidth * 1.5;
+      final numDots = (sprayRadius * 0.8).round();
+
+      for (int i = 0; i < numDots; i++) {
+        final angle = (i / numDots) * 2 * math.pi;
+        final distance = math.Random().nextDouble() * sprayRadius;
+        final dotOffset = Offset(
+          point.offset.dx + math.cos(angle) * distance,
+          point.offset.dy + math.sin(angle) * distance,
+        );
+
+        final dotPaint = Paint()
+          ..color = basePaint.color.withValues(alpha: 0.3)
+          ..style = PaintingStyle.fill;
+
+        canvas.drawCircle(dotOffset, 1.0, dotPaint);
+      }
+    }
+  }
+
+  void _renderCharcoal(Canvas canvas, DrawPath path) {
+    final points = path.points;
+    final basePaint = points.first.paint;
+
+    // Create textured charcoal effect
+    if (points.length == 1) {
+      canvas.drawCircle(
+          points.first.offset, basePaint.strokeWidth / 2, basePaint);
+    } else {
+      // Draw multiple overlapping strokes for texture
+      for (int layer = 0; layer < 3; layer++) {
+        final layerPaint = Paint()
+          ..color = basePaint.color.withValues(alpha: 0.3)
+          ..strokeWidth = basePaint.strokeWidth + layer * 2
+          ..strokeCap = StrokeCap.round
+          ..style = PaintingStyle.stroke;
+
         final drawPath = Path();
         drawPath.moveTo(points.first.offset.dx, points.first.offset.dy);
 
@@ -35,7 +121,89 @@ class DrawingPainter extends CustomPainter {
           drawPath.lineTo(points[i].offset.dx, points[i].offset.dy);
         }
 
-        canvas.drawPath(drawPath, paint);
+        canvas.drawPath(drawPath, layerPaint);
+      }
+    }
+  }
+
+  void _renderWatercolor(Canvas canvas, DrawPath path) {
+    final points = path.points;
+    final basePaint = points.first.paint;
+
+    // Create watercolor bleeding effect with larger, softer strokes
+    if (points.length == 1) {
+      // Single point with soft edges
+      final paint1 = Paint()
+        ..color = basePaint.color.withValues(alpha: 0.3)
+        ..style = PaintingStyle.fill;
+      canvas.drawCircle(
+          points.first.offset, basePaint.strokeWidth * 1.5, paint1);
+
+      final paint2 = Paint()
+        ..color = basePaint.color.withValues(alpha: 0.5)
+        ..style = PaintingStyle.fill;
+      canvas.drawCircle(points.first.offset, basePaint.strokeWidth, paint2);
+    } else {
+      // Multiple soft layers for bleeding effect
+      for (int layer = 2; layer >= 0; layer--) {
+        final layerPaint = Paint()
+          ..color = basePaint.color.withValues(alpha: 0.2 + layer * 0.1)
+          ..strokeWidth = basePaint.strokeWidth * (1.5 - layer * 0.2)
+          ..strokeCap = StrokeCap.round
+          ..style = PaintingStyle.stroke;
+
+        final drawPath = Path();
+        drawPath.moveTo(points.first.offset.dx, points.first.offset.dy);
+
+        for (int i = 1; i < points.length; i++) {
+          drawPath.lineTo(points[i].offset.dx, points[i].offset.dy);
+        }
+
+        canvas.drawPath(drawPath, layerPaint);
+      }
+    }
+  }
+
+  void _renderOilPaint(Canvas canvas, DrawPath path) {
+    final points = path.points;
+    final basePaint = points.first.paint;
+
+    // Create thick, textured oil paint effect
+    if (points.length == 1) {
+      canvas.drawCircle(
+          points.first.offset, basePaint.strokeWidth / 2, basePaint);
+    } else {
+      // Draw main stroke
+      final mainPath = Path();
+      mainPath.moveTo(points.first.offset.dx, points.first.offset.dy);
+
+      for (int i = 1; i < points.length; i++) {
+        mainPath.lineTo(points[i].offset.dx, points[i].offset.dy);
+      }
+
+      canvas.drawPath(mainPath, basePaint);
+
+      // Add texture with slightly offset strokes
+      for (int texture = 0; texture < 2; texture++) {
+        final texturePaint = Paint()
+          ..color = basePaint.color.withValues(alpha: 0.4)
+          ..strokeWidth = basePaint.strokeWidth * 0.7
+          ..strokeCap = StrokeCap.round
+          ..style = PaintingStyle.stroke;
+
+        final texturePath = Path();
+        final offsetX = (texture - 0.5) * 2;
+        final offsetY = (texture - 0.5) * 2;
+
+        texturePath.moveTo(
+            points.first.offset.dx + offsetX, points.first.offset.dy + offsetY);
+
+        for (int i = 1; i < points.length; i++) {
+          texturePath.lineTo(
+              points[i].offset.dx + offsetX, points[i].offset.dy + offsetY);
+        }
+
+        canvas.drawPath(texturePath, texturePaint);
       }
     }
   }

--- a/lib/ui/widgets/drawing/drawing_painter.dart
+++ b/lib/ui/widgets/drawing/drawing_painter.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import '../../../models/draw_model.dart';
-import 'dart:math' as math;
 
 class DrawingPainter extends CustomPainter {
   final List<DrawPath> paths;
@@ -32,23 +31,8 @@ class DrawingPainter extends CustomPainter {
     final points = path.points;
     if (points.isEmpty) return;
 
-    switch (path.brushType) {
-      case BrushType.sprayPaint:
-        _renderSprayPaint(canvas, path);
-        break;
-      case BrushType.charcoal:
-        _renderCharcoal(canvas, path);
-        break;
-      case BrushType.watercolor:
-        _renderWatercolor(canvas, path);
-        break;
-      case BrushType.oilPaint:
-        _renderOilPaint(canvas, path);
-        break;
-      default:
-        _renderStandardStroke(canvas, path);
-        break;
-    }
+    // All brush types use standard stroke rendering
+    _renderStandardStroke(canvas, path);
   }
 
   void _renderStandardStroke(Canvas canvas, DrawPath path) {
@@ -68,143 +52,6 @@ class DrawingPainter extends CustomPainter {
       }
 
       canvas.drawPath(drawPath, paint);
-    }
-  }
-
-  void _renderSprayPaint(Canvas canvas, DrawPath path) {
-    final points = path.points;
-    final basePaint = points.first.paint;
-
-    // Create spray effect with multiple small dots
-    for (var point in points) {
-      final sprayRadius = basePaint.strokeWidth * 1.5;
-      final numDots = (sprayRadius * 0.8).round();
-
-      for (int i = 0; i < numDots; i++) {
-        final angle = (i / numDots) * 2 * math.pi;
-        final distance = math.Random().nextDouble() * sprayRadius;
-        final dotOffset = Offset(
-          point.offset.dx + math.cos(angle) * distance,
-          point.offset.dy + math.sin(angle) * distance,
-        );
-
-        final dotPaint = Paint()
-          ..color = basePaint.color.withValues(alpha: 0.3)
-          ..style = PaintingStyle.fill;
-
-        canvas.drawCircle(dotOffset, 1.0, dotPaint);
-      }
-    }
-  }
-
-  void _renderCharcoal(Canvas canvas, DrawPath path) {
-    final points = path.points;
-    final basePaint = points.first.paint;
-
-    // Create textured charcoal effect
-    if (points.length == 1) {
-      canvas.drawCircle(
-          points.first.offset, basePaint.strokeWidth / 2, basePaint);
-    } else {
-      // Draw multiple overlapping strokes for texture
-      for (int layer = 0; layer < 3; layer++) {
-        final layerPaint = Paint()
-          ..color = basePaint.color.withValues(alpha: 0.3)
-          ..strokeWidth = basePaint.strokeWidth + layer * 2
-          ..strokeCap = StrokeCap.round
-          ..style = PaintingStyle.stroke;
-
-        final drawPath = Path();
-        drawPath.moveTo(points.first.offset.dx, points.first.offset.dy);
-
-        for (int i = 1; i < points.length; i++) {
-          drawPath.lineTo(points[i].offset.dx, points[i].offset.dy);
-        }
-
-        canvas.drawPath(drawPath, layerPaint);
-      }
-    }
-  }
-
-  void _renderWatercolor(Canvas canvas, DrawPath path) {
-    final points = path.points;
-    final basePaint = points.first.paint;
-
-    // Create watercolor bleeding effect with larger, softer strokes
-    if (points.length == 1) {
-      // Single point with soft edges
-      final paint1 = Paint()
-        ..color = basePaint.color.withValues(alpha: 0.3)
-        ..style = PaintingStyle.fill;
-      canvas.drawCircle(
-          points.first.offset, basePaint.strokeWidth * 1.5, paint1);
-
-      final paint2 = Paint()
-        ..color = basePaint.color.withValues(alpha: 0.5)
-        ..style = PaintingStyle.fill;
-      canvas.drawCircle(points.first.offset, basePaint.strokeWidth, paint2);
-    } else {
-      // Multiple soft layers for bleeding effect
-      for (int layer = 2; layer >= 0; layer--) {
-        final layerPaint = Paint()
-          ..color = basePaint.color.withValues(alpha: 0.2 + layer * 0.1)
-          ..strokeWidth = basePaint.strokeWidth * (1.5 - layer * 0.2)
-          ..strokeCap = StrokeCap.round
-          ..style = PaintingStyle.stroke;
-
-        final drawPath = Path();
-        drawPath.moveTo(points.first.offset.dx, points.first.offset.dy);
-
-        for (int i = 1; i < points.length; i++) {
-          drawPath.lineTo(points[i].offset.dx, points[i].offset.dy);
-        }
-
-        canvas.drawPath(drawPath, layerPaint);
-      }
-    }
-  }
-
-  void _renderOilPaint(Canvas canvas, DrawPath path) {
-    final points = path.points;
-    final basePaint = points.first.paint;
-
-    // Create thick, textured oil paint effect
-    if (points.length == 1) {
-      canvas.drawCircle(
-          points.first.offset, basePaint.strokeWidth / 2, basePaint);
-    } else {
-      // Draw main stroke
-      final mainPath = Path();
-      mainPath.moveTo(points.first.offset.dx, points.first.offset.dy);
-
-      for (int i = 1; i < points.length; i++) {
-        mainPath.lineTo(points[i].offset.dx, points[i].offset.dy);
-      }
-
-      canvas.drawPath(mainPath, basePaint);
-
-      // Add texture with slightly offset strokes
-      for (int texture = 0; texture < 2; texture++) {
-        final texturePaint = Paint()
-          ..color = basePaint.color.withValues(alpha: 0.4)
-          ..strokeWidth = basePaint.strokeWidth * 0.7
-          ..strokeCap = StrokeCap.round
-          ..style = PaintingStyle.stroke;
-
-        final texturePath = Path();
-        final offsetX = (texture - 0.5) * 2;
-        final offsetY = (texture - 0.5) * 2;
-
-        texturePath.moveTo(
-            points.first.offset.dx + offsetX, points.first.offset.dy + offsetY);
-
-        for (int i = 1; i < points.length; i++) {
-          texturePath.lineTo(
-              points[i].offset.dx + offsetX, points[i].offset.dy + offsetY);
-        }
-
-        canvas.drawPath(texturePath, texturePaint);
-      }
     }
   }
 

--- a/lib/ui/widgets/drawing/drawing_tools_panel.dart
+++ b/lib/ui/widgets/drawing/drawing_tools_panel.dart
@@ -1,20 +1,67 @@
 import 'package:flutter/material.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
 import '../../../constants/color_constants.dart';
+import '../../../models/draw_model.dart';
 
 class DrawingToolsPanel extends StatelessWidget {
   final Color currentColor;
   final double currentStrokeWidth;
+  final BrushType currentBrushType;
   final Function(Color) onColorChanged;
   final Function(double) onStrokeWidthChanged;
+  final Function(BrushType) onBrushTypeChanged;
 
   const DrawingToolsPanel({
     super.key,
     required this.currentColor,
     required this.currentStrokeWidth,
+    required this.currentBrushType,
     required this.onColorChanged,
     required this.onStrokeWidthChanged,
+    required this.onBrushTypeChanged,
   });
+
+  String _getBrushTypeName(BrushType brushType) {
+    switch (brushType) {
+      case BrushType.brush:
+        return 'Brush';
+      case BrushType.marker:
+        return 'Marker';
+      case BrushType.highlighter:
+        return 'Highlighter';
+      case BrushType.pencil:
+        return 'Pencil';
+      case BrushType.watercolor:
+        return 'Watercolor';
+      case BrushType.oilPaint:
+        return 'Oil Paint';
+      case BrushType.charcoal:
+        return 'Charcoal';
+      case BrushType.sprayPaint:
+        return 'Spray Paint';
+    }
+  }
+
+  IconData _getBrushTypeIcon(BrushType brushType) {
+    switch (brushType) {
+      case BrushType.brush:
+        return Icons.brush;
+      case BrushType.marker:
+        return Icons.edit;
+      case BrushType.highlighter:
+        return Icons.highlight;
+      case BrushType.pencil:
+        return Icons.create;
+      case BrushType.watercolor:
+        return Icons.water_drop;
+      case BrushType.oilPaint:
+        return Icons.palette;
+      case BrushType.charcoal:
+        return Icons.blur_on;
+      case BrushType.sprayPaint:
+        return Icons.grain;
+    }
+  }
 
   void _showColorPicker(BuildContext context) {
     showDialog(
@@ -107,6 +154,79 @@ class DrawingToolsPanel extends StatelessWidget {
             ),
           ),
 
+          // Brush Type section
+          Text(
+            'Brush Type',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              fontSize: 12,
+            ),
+          ),
+          const SizedBox(height: 2),
+
+          // Brush type grid
+          GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            padding: EdgeInsets.zero,
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              crossAxisSpacing: 6,
+              mainAxisSpacing: 6,
+              childAspectRatio: 1.2,
+            ),
+            itemCount: BrushType.values.length,
+            itemBuilder: (context, index) {
+              final brushType = BrushType.values[index];
+              final isSelected = currentBrushType == brushType;
+
+              return InkWell(
+                onTap: () => onBrushTypeChanged(brushType),
+                borderRadius: BorderRadius.circular(8),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: isSelected
+                        ? ColorConstants.dialogButtonBlue.withValues(alpha: 0.1)
+                        : ColorConstants.gray50,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: isSelected
+                          ? ColorConstants.dialogButtonBlue
+                          : ColorConstants.gray200,
+                      width: isSelected ? 2 : 1,
+                    ),
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        _getBrushTypeIcon(brushType),
+                        size: 18,
+                        color: isSelected
+                            ? ColorConstants.dialogButtonBlue
+                            : ColorConstants.gray600,
+                      ),
+                      // const SizedBox(height: 4),
+                      Text(
+                        _getBrushTypeName(brushType),
+                        style: TextStyle(
+                          fontSize: 8,
+                          fontWeight:
+                              isSelected ? FontWeight.w600 : FontWeight.w400,
+                          color: isSelected
+                              ? ColorConstants.dialogButtonBlue
+                              : ColorConstants.gray600,
+                        ),
+                        textAlign: TextAlign.center,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+
           // Color picker section
           Text(
             'Color',
@@ -115,7 +235,7 @@ class DrawingToolsPanel extends StatelessWidget {
               fontSize: 12,
             ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: 2),
 
           // Color display box with color code
           GestureDetector(
@@ -211,7 +331,7 @@ class DrawingToolsPanel extends StatelessWidget {
             ),
           ),
 
-          const SizedBox(height: 16),
+          // const SizedBox(height: 16),
 
           // Brush size section
           Text(
@@ -221,7 +341,7 @@ class DrawingToolsPanel extends StatelessWidget {
               fontSize: 12,
             ),
           ),
-          const SizedBox(height: 8),
+          // const SizedBox(height: 8),
 
           // Size preview circle
           Container(
@@ -253,7 +373,7 @@ class DrawingToolsPanel extends StatelessWidget {
             ),
           ),
 
-          const SizedBox(height: 8),
+          // const SizedBox(height: 8),
 
           // Size slider
           SizedBox(
@@ -280,7 +400,7 @@ class DrawingToolsPanel extends StatelessWidget {
             ),
           ),
 
-          const SizedBox(height: 4),
+          // const SizedBox(height: 4),
 
           // Size value display
           Text(

--- a/lib/ui/widgets/drawing/drawing_tools_panel.dart
+++ b/lib/ui/widgets/drawing/drawing_tools_panel.dart
@@ -27,18 +27,6 @@ class DrawingToolsPanel extends StatelessWidget {
         return 'Brush';
       case BrushType.marker:
         return 'Marker';
-      case BrushType.highlighter:
-        return 'Highlighter';
-      case BrushType.pencil:
-        return 'Pencil';
-      case BrushType.watercolor:
-        return 'Watercolor';
-      case BrushType.oilPaint:
-        return 'Oil Paint';
-      case BrushType.charcoal:
-        return 'Charcoal';
-      case BrushType.sprayPaint:
-        return 'Spray Paint';
     }
   }
 
@@ -48,18 +36,6 @@ class DrawingToolsPanel extends StatelessWidget {
         return Icons.brush;
       case BrushType.marker:
         return Icons.edit;
-      case BrushType.highlighter:
-        return Icons.highlight;
-      case BrushType.pencil:
-        return Icons.create;
-      case BrushType.watercolor:
-        return Icons.water_drop;
-      case BrushType.oilPaint:
-        return Icons.palette;
-      case BrushType.charcoal:
-        return Icons.blur_on;
-      case BrushType.sprayPaint:
-        return Icons.grain;
     }
   }
 
@@ -175,9 +151,10 @@ class DrawingToolsPanel extends StatelessWidget {
               mainAxisSpacing: 6,
               childAspectRatio: 1.2,
             ),
-            itemCount: BrushType.values.length,
+            itemCount: 2, // Only brush and marker
             itemBuilder: (context, index) {
-              final brushType = BrushType.values[index];
+              final availableBrushTypes = [BrushType.brush, BrushType.marker];
+              final brushType = availableBrushTypes[index];
               final isSelected = currentBrushType == brushType;
 
               return InkWell(

--- a/lib/ui/widgets/drawing/drawing_tools_panel.dart
+++ b/lib/ui/widgets/drawing/drawing_tools_panel.dart
@@ -183,7 +183,6 @@ class DrawingToolsPanel extends StatelessWidget {
                             ? ColorConstants.dialogButtonBlue
                             : ColorConstants.gray600,
                       ),
-                      // const SizedBox(height: 4),
                       Text(
                         _getBrushTypeName(brushType),
                         style: TextStyle(
@@ -308,8 +307,6 @@ class DrawingToolsPanel extends StatelessWidget {
             ),
           ),
 
-          // const SizedBox(height: 16),
-
           // Brush size section
           Text(
             'Size',
@@ -318,7 +315,6 @@ class DrawingToolsPanel extends StatelessWidget {
               fontSize: 12,
             ),
           ),
-          // const SizedBox(height: 8),
 
           // Size preview circle
           Container(
@@ -350,8 +346,6 @@ class DrawingToolsPanel extends StatelessWidget {
             ),
           ),
 
-          // const SizedBox(height: 8),
-
           // Size slider
           SizedBox(
             width: 100,
@@ -376,8 +370,6 @@ class DrawingToolsPanel extends StatelessWidget {
               ),
             ),
           ),
-
-          // const SizedBox(height: 4),
 
           // Size value display
           Text(

--- a/lib/ui/widgets/drawing_canvas.dart
+++ b/lib/ui/widgets/drawing_canvas.dart
@@ -9,11 +9,13 @@ class DrawingCanvas extends StatefulWidget {
   final bool isDrawingMode;
   final Color currentDrawColor;
   final double currentStrokeWidth;
+  final BrushType currentBrushType;
   final Function(Offset) onStartDrawing;
   final Function(Offset) onUpdateDrawing;
   final Function() onEndDrawing;
   final Function(Color) onColorChanged;
   final Function(double) onStrokeWidthChanged;
+  final Function(BrushType) onBrushTypeChanged;
   final Function() onUndoDrawing;
   final Function() onClearDrawing;
 
@@ -23,11 +25,13 @@ class DrawingCanvas extends StatefulWidget {
     required this.isDrawingMode,
     required this.currentDrawColor,
     required this.currentStrokeWidth,
+    required this.currentBrushType,
     required this.onStartDrawing,
     required this.onUpdateDrawing,
     required this.onEndDrawing,
     required this.onColorChanged,
     required this.onStrokeWidthChanged,
+    required this.onBrushTypeChanged,
     required this.onUndoDrawing,
     required this.onClearDrawing,
   });
@@ -94,8 +98,10 @@ class _DrawingCanvasState extends State<DrawingCanvas> {
                       child: DrawingToolsPanel(
                         currentColor: widget.currentDrawColor,
                         currentStrokeWidth: widget.currentStrokeWidth,
+                        currentBrushType: widget.currentBrushType,
                         onColorChanged: (_) {}, // No-op in feedback
                         onStrokeWidthChanged: (_) {}, // No-op in feedback
+                        onBrushTypeChanged: (_) {}, // No-op in feedback
                       ),
                     ),
                   ),
@@ -128,8 +134,10 @@ class _DrawingCanvasState extends State<DrawingCanvas> {
                   child: DrawingToolsPanel(
                     currentColor: widget.currentDrawColor,
                     currentStrokeWidth: widget.currentStrokeWidth,
+                    currentBrushType: widget.currentBrushType,
                     onColorChanged: widget.onColorChanged,
                     onStrokeWidthChanged: widget.onStrokeWidthChanged,
+                    onBrushTypeChanged: widget.onBrushTypeChanged,
                   ),
                 ),
               ),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

Feature — enhancement of the drawing canvas with multiple brush types (Brush and Marker) and improved toolbar access.

### Issue Number:

Fixes #108

### Snapshots/Videos:

https://github.com/user-attachments/assets/1bed4acc-bdd8-4054-b683-ed7346cd753c

### Summary

This PR expands the drawing tools by introducing a dedicated "Brush Types" selection and adding a Marker tool alongside the existing Brush. The draw button now exposes brush options in the toolbar (compact 2x1 grid) so users can pick the tool before or during drawing. Both tools preserve existing color and stroke controls.

Key changes:

- Added Marker behavior alongside Brush with distinct paint config:
- - `Brush:` solid, opaque strokes (FilterQuality.high)
- - `Marker: `semi-transparent strokes (~70% opacity), wider by default (1.5x), medium filter quality
- UI: compact grid in the drawing tools panel with icons and names; clear highlight for selected tool
- State: `currentBrushType` tracked in canvas state and managed via cubit (`setBrushType`)
- Centralized paint creation in cubit via `_createPaintForBrush`
- Kept color picker and stroke width slider unchanged

### Does this PR introduce a breaking change?
Nope

### Other information
Future work: we can add additional brush types (watercolor, oil paint, spray, charcoal, highlighter, pencil) using the same pattern (enum + paint configuration + optional custom rendering). Do you want me to proceed and add those next?

### Have you read the [contributing guide](https://github.com/may-tas/TextEditingApp/blob/main/CONTRIBUTING.md) , [README.md](https://github.com/may-tas/TextEditingApp/blob/main/README.md) , [code of conduct](https://github.com/may-tas/TextEditingApp/blob/main/CODE_OF_CONDUCT.md)?
Yes
