### PR TITLE
Fixed `contributors.yml` script to run optimally

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,11 +1,11 @@
 name: Contributors
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    types: [ closed ]
+    types: [closed]
   schedule:
-    - cron: '0 2 * * 1'
+    - cron: "0 2 * * 1"
   workflow_dispatch:
 
 jobs:
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' || 
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || 
+      (github.event_name == 'pull_request' && 
+       github.event.pull_request.merged == true && 
+       github.event.pull_request.user.login != 'github-actions[bot]') || 
       github.event_name == 'schedule' || 
       github.event_name == 'workflow_dispatch'
     permissions:


### PR DESCRIPTION
### What kind of change does this PR introduce?

- Added a condition to exclude PRs created by github-actions[bot]

### Issue Number:

- Fixes #137 

### Summary
Now the workflow will:
- Run on push to main
- Run when a genuine user's PR is merged
- Run on schedule (weekly on Mondays at 2 AM)
- Run on manual dispatch
- NOT run when the bot's own PR is merged (preventing the loop)

### Does this PR introduce a breaking change?

- No

### Have you read the [contributing guide](https://github.com/may-tas/TextEditingApp/blob/main/CONTRIBUTING.md) , [README.md](https://github.com/may-tas/TextEditingApp/blob/main/README.md) , [code of conduct](https://github.com/may-tas/TextEditingApp/blob/main/CODE_OF_CONDUCT.md)?

- Yes
